### PR TITLE
fix(ci): drop conflicting pnpm@latest workflow override

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,6 @@ jobs:
         uses: withastro/action@v3
         with:
           node-version: 24
-          package-manager: pnpm@latest
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary

The post-merge deploy of #2 failed with `ERR_PNPM_BAD_PM_VERSION`: the workflow declared `package-manager: pnpm@latest` while `package.json` pins `packageManager: pnpm@10.11.1`. `pnpm/action-setup` rejects the mismatch.

Drop the workflow override — `withastro/action` detects pnpm from the lockfile, then `pnpm/action-setup` honors the `packageManager` pin from `package.json`. Single version source.

[Failed run](https://github.com/ALRubinger/exitcondition.alrubinger.com/actions/runs/26782823466).

## Test plan

- [x] Workflow YAML still valid (single integration step removed one input line)
- [ ] Post-merge deploy succeeds and the new site is live

🤖 Generated with [Claude Code](https://claude.com/claude-code)