### PR TITLE
ci: add PR-time install + check + build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+# Catch build / type-check breakage on PRs before it lands on main and
+# auto-deploys to production via deploy.yml.
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm check
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Summary

\`deploy.yml\` only runs on push to main and ships straight to production. Without a PR-time signal, breakage shows up post-merge — exactly what happened with PR #2 (where #3 had to fix it forward).

This new \`ci.yml\` runs on \`pull_request\` to main:

1. \`actions/checkout@v6\`
2. \`pnpm/action-setup@v5\` (reads \`packageManager\` from package.json → pnpm 10.11.1)
3. \`actions/setup-node@v6\` with \`node-version-file: .nvmrc\` (→ Node 24) + pnpm cache
4. \`pnpm install --frozen-lockfile\` (fails fast if the lockfile drifts)
5. \`pnpm check\` (astro check / TS)
6. \`pnpm build\`

This PR is itself the first test of the workflow.

## Test plan

- [x] Workflow YAML valid (\`actionlint\` would catch parse errors)
- [ ] CI workflow runs on this PR and passes
- [ ] After merge, deploy still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)