### PR TITLE
feat(blog): wrap title, date, and AuthorCard in a header card

### DIFF
--- a/src/components/blog/PostHeader.astro
+++ b/src/components/blog/PostHeader.astro
@@ -1,0 +1,120 @@
+---
+import { Image } from 'astro:assets';
+import type { ImageMetadata } from 'astro';
+import type { CollectionEntry } from 'astro:content';
+import AuthorCard from './AuthorCard.astro';
+import { formatDateLong } from '../../lib/posts';
+
+interface Props {
+  title: string;
+  date: Date;
+  author?: CollectionEntry<'authors'>;
+  image?: string;
+}
+
+const { title, date, author, image } = Astro.props;
+
+const imageDir = '/src/assets/blog/';
+const imagePath = image ? imageDir + image : undefined;
+// import.meta.glob requires a string literal, so we can't interpolate imageDir.
+const heroImages = import.meta.glob<{ default: ImageMetadata }>(
+  '/src/assets/blog/*.{jpeg,jpg,png,gif,webp,avif}',
+);
+if (imagePath && !heroImages[imagePath]) {
+  throw new Error(`Post hero image "${imagePath}" does not exist`);
+}
+---
+
+<header class="post-header">
+  <div class="post-header-text">
+    <h1 class="post-header-title">{title}</h1>
+    <p class="post-header-date">
+      Published on{' '}
+      <b><time datetime={date.toISOString()}>{formatDateLong(date)}</time></b>
+    </p>
+    {author && (
+      <div class="post-header-author">
+        <AuthorCard author={author} />
+      </div>
+    )}
+  </div>
+  {imagePath && (
+    <div class="post-header-hero">
+      <Image
+        src={heroImages[imagePath]()}
+        alt={title}
+        width={800}
+        height={600}
+        class="post-header-hero-img"
+      />
+    </div>
+  )}
+</header>
+
+<style>
+  .post-header {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    margin-bottom: 2.5rem;
+    background: var(--muted);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+  }
+  .post-header-text {
+    padding: 1.5rem;
+  }
+  .post-header-title {
+    font-size: 2.25rem;
+    font-weight: var(--role-display-weight);
+    line-height: var(--role-display-line-height);
+    letter-spacing: var(--role-display-tracking);
+    margin: 0;
+    color: var(--foreground);
+    filter: var(--effect-ink-bleed);
+  }
+  .post-header-date {
+    margin: 0.5rem 0 0;
+    font-size: 0.875rem;
+    font-style: italic;
+    color: var(--muted-foreground);
+  }
+  .post-header-date b {
+    font-weight: 600;
+    color: var(--foreground);
+  }
+  .post-header-author {
+    margin-top: 1.25rem;
+  }
+  .post-header-hero {
+    flex: none;
+    order: 99;
+  }
+  .post-header-hero-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  @media (min-width: 640px) {
+    .post-header-title { font-size: 3rem; }
+  }
+  @media (min-width: 1024px) {
+    .post-header {
+      flex-direction: row;
+      gap: 1.5rem;
+    }
+    .post-header-text {
+      flex: 1;
+      padding: 1.5rem 0 1.5rem 1.5rem;
+    }
+    .post-header-title {
+      font-size: var(--role-display-size);
+    }
+    .post-header-hero {
+      order: 0;
+      max-width: 20rem;
+    }
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,6 +10,7 @@ const posts = defineCollection({
     date: z.coerce.date(),
     draft: z.boolean().default(false),
     author: z.string().optional(),
+    image: z.string().optional(),
   }),
 });
 

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -2,18 +2,18 @@
 import type { CollectionEntry } from 'astro:content';
 import BaseLayout from './BaseLayout.astro';
 import TableOfContents from '../components/TableOfContents.svelte';
-import AuthorCard from '../components/blog/AuthorCard.astro';
-import { formatDate } from '../lib/posts';
+import PostHeader from '../components/blog/PostHeader.astro';
 
 interface Props {
   title: string;
   description?: string;
   date: Date;
   author?: CollectionEntry<'authors'>;
+  image?: string;
   headings?: { slug: string; text: string; depth: number }[];
 }
 
-const { title, description, date, author, headings = [] } = Astro.props;
+const { title, description, date, author, image, headings = [] } = Astro.props;
 ---
 
 <BaseLayout title={title} description={description}>
@@ -21,15 +21,9 @@ const { title, description, date, author, headings = [] } = Astro.props;
     <div class="flex gap-8">
       <div class="flex-1 min-w-0">
         <article class="prose">
-          <h1>{title}</h1>
-          <p class="meta text-sm text-muted-foreground -mt-4 mb-8">
-            <time datetime={date.toISOString()}>{formatDate(date)}</time>
-          </p>
-          {author && (
-            <div class="not-prose mb-10">
-              <AuthorCard author={author} />
-            </div>
-          )}
+          <div class="not-prose">
+            <PostHeader title={title} date={date} author={author} image={image} />
+          </div>
           <slot />
         </article>
       </div>

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -34,3 +34,13 @@ export function formatDate(date: Date): string {
     timeZone: 'UTC',
   });
 }
+
+export function formatDateLong(date: Date): string {
+  return date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -38,6 +38,7 @@ const components = { SectionBreak, SectionResume };
   description={entry.data.description}
   date={entry.data.date}
   author={author}
+  image={entry.data.image}
   headings={headings}
 >
   <Content components={components} />


### PR DESCRIPTION
## Summary
- Ports the Block docs-site-kickstarter blog-header layout: title, "Published on <long date>", and the AuthorCard sit together inside a single muted-background rounded panel above the article body.
- Adds an optional `image` frontmatter field on posts. When set, a hero image fills the right column on `lg+` and stacks on top below it; when absent, the card is left-column only.
- Date in the header uses a new `formatDateLong` (e.g. "Monday, June 1, 2026"); the sidebar index keeps the short form.

## Notes
- The header lives inside the prose container as a `not-prose` block, so it inherits the article's max-width but escapes prose typography. The title's display styling is recreated explicitly so the ink-bleed and breakpoint sizing still match the existing prose h1.
- Hero images resolve via `import.meta.glob` against `src/assets/blog/*.{jpeg,jpg,png,gif,webp,avif}`, matching the avatar pattern from the AuthorCard. A missing file throws at render time with a named error.
- hello-world has no image yet, so this PR exercises the left-column-only path; adding `image: foo.jpg` later picks up the right column with no further changes.

## Test plan
- [x] `pnpm check` — 0 errors / 0 warnings / 0 hints across 14 Astro files.
- [x] `pnpm build` — 2 pages built; avatar optimized.
- [x] `pnpm dev` + GET `/posts/hello-world/` — header card renders with muted background, "Hello, world" title, italic "Published on **Monday, June 1, 2026**", AuthorCard below; no hero column (correct, image not set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)