### PR TITLE
feat(blog): tighten chatbots post + add Points components

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.8",
     "@tailwindcss/vite": "^4.2.2",
+    "@types/node": "^24.13.2",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,16 +13,16 @@ importers:
         version: 7.2.0
       '@astrojs/mdx':
         specifier: ^6.0.1
-        version: 6.0.1(astro@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0))
+        version: 6.0.1(astro@6.4.2(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0))
       '@astrojs/svelte':
         specifier: ^8.0.5
-        version: 8.1.2(astro@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(svelte@5.56.0)(typescript@6.0.3)(yaml@2.9.0)
+        version: 8.1.2(@types/node@24.13.2)(astro@6.4.2(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(svelte@5.56.0)(typescript@6.0.3)(yaml@2.9.0)
       '@lucide/svelte':
         specifier: ^1.16.0
         version: 1.17.0(svelte@5.56.0)
       astro:
         specifier: ^6.1.6
-        version: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0)
+        version: 6.4.2(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0)
       rehype-external-links:
         specifier: ^3.0.0
         version: 3.0.0
@@ -41,7 +41,10 @@ importers:
         version: 0.9.9(prettier@3.8.3)(typescript@6.0.3)
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.3.0(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+        version: 4.3.0(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.2
       tailwindcss:
         specifier: ^4.2.2
         version: 4.3.0
@@ -781,6 +784,9 @@ packages:
 
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
+
+  '@types/node@24.13.2':
+    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -1875,6 +1881,9 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -2254,13 +2263,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@6.0.1(astro@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0))':
+  '@astrojs/mdx@6.0.1(astro@6.4.2(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
       '@astrojs/markdown-remark': 7.2.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0)
+      astro: 6.4.2(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -2278,15 +2287,15 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/svelte@8.1.2(astro@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(svelte@5.56.0)(typescript@6.0.3)(yaml@2.9.0)':
+  '@astrojs/svelte@8.1.2(@types/node@24.13.2)(astro@6.4.2(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0))(jiti@2.7.0)(lightningcss@1.32.0)(svelte@5.56.0)(typescript@6.0.3)(yaml@2.9.0)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.0)(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
-      astro: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0)
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.0)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      astro: 6.4.2(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0)
       svelte: 5.56.0
       svelte2tsx: 0.7.56(svelte@5.56.0)(typescript@6.0.3)
       typescript: 6.0.3
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      vite: 7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2725,22 +2734,22 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0)(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.0)(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.0)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.0)(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.56.0)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       obug: 2.1.1
       svelte: 5.56.0
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0)(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0)(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.0)(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.0)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.0)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.56.0
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      vite: 7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
 
   '@tailwindcss/node@4.3.0':
     dependencies:
@@ -2803,12 +2812,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.0(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
 
   '@types/debug@4.1.13':
     dependencies:
@@ -2835,6 +2844,10 @@ snapshots:
   '@types/nlcst@2.0.3':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/node@24.13.2':
+    dependencies:
+      undici-types: 7.18.2
 
   '@types/trusted-types@2.0.7': {}
 
@@ -2932,7 +2945,7 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro@6.4.2(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0):
+  astro@6.4.2(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.61.0)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@astrojs/internal-helpers': 0.10.0
@@ -2984,8 +2997,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+      vite: 7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -4463,6 +4476,8 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
+  undici-types@7.18.2: {}
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -4551,7 +4566,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0):
+  vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4560,14 +4575,15 @@ snapshots:
       rollup: 4.61.0
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 24.13.2
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
+      vite: 7.3.5(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)
 
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:

--- a/src/components/BlinkingEyes.astro
+++ b/src/components/BlinkingEyes.astro
@@ -1,18 +1,22 @@
 ---
-// Inline blinking-eyes glyph. Sits on the text baseline like an emoji,
-// scales with surrounding font-size (1em), and inherits the text color
-// via currentColor. Self-contained: vector + CSS keyframe, no JS, no
-// external assets. Respects prefers-reduced-motion per DESIGN.md's
-// motion rule.
+// Inline blinking-eyes glyph. Cartoon-style eyes (white sclera, thick
+// black rim, offset black pupil, small white highlight) that sit on
+// the text baseline like an emoji, scale with surrounding font-size,
+// and inherit text color via currentColor. Self-contained: vector +
+// CSS keyframe, no JS, no external assets. Respects
+// prefers-reduced-motion per DESIGN.md's motion rule.
 //
-// Each eye is two layered ellipses: an outlined sclera (the "white"
-// of the eye, filled with --card so it stays visibly lighter than any
-// surface the glyph lands on, outlined in currentColor), and an iris
-// filled in currentColor inside it. Both layers share the same blink
-// keyframes and the same transform-origin per eye, so the WHOLE eye
-// closes together — sclera and iris collapse in lockstep to a thin
-// horizontal line. Cadence loosely tuned to a brisk human blink rate
-// (~30/min on a 2s default cycle).
+// Each eye is a <g> containing four circles: rim (outer black), sclera
+// (white center), pupil (black, offset upper-right inside the sclera),
+// and highlight (small white dot on the pupil). The wrapping <g>'s
+// transform-origin is its own bounding-box center, so the WHOLE eye
+// collapses together — rim, sclera, pupil, and highlight squish in
+// lockstep to a thin horizontal lens. Both eyes share the same keyframes
+// so they blink in sync. Geometry comes from the public-domain
+// cartoon-eyes artwork on Openclipart, re-coordinated into a natural
+// top-down y-axis (the original used a flipped scale(1 -1) /
+// translate(0 -300) trick that we've baked out). Cadence loosely tuned
+// to a brisk human blink rate (~30/min on a 2s default cycle).
 
 interface Props {
   /** CSS time string for the full blink cycle. Lower = blinks more
@@ -36,22 +40,30 @@ const { interval = '2s', label } = Astro.props;
 >
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
+    viewBox="0 0 600 300"
     focusable="false"
     aria-hidden="true"
   >
-    <ellipse class="be-sclera" cx="7" cy="12" rx="2.5" ry="3.5" />
-    <ellipse class="be-iris" cx="7" cy="12" rx="1.8" ry="1.8" />
-    <ellipse class="be-sclera" cx="17" cy="12" rx="2.5" ry="3.5" />
-    <ellipse class="be-iris" cx="17" cy="12" rx="1.8" ry="1.8" />
+    <g class="be-eye">
+      <circle class="be-rim" cx="157.58" cy="154.43" r="126.82" />
+      <circle class="be-sclera" cx="157.58" cy="154.43" r="110.46" />
+      <circle class="be-pupil" cx="200.39" cy="151.84" r="48.56" />
+      <circle class="be-highlight" cx="221.62" cy="136.45" r="12.36" />
+    </g>
+    <g class="be-eye">
+      <circle class="be-rim" cx="433.47" cy="155.46" r="126.82" />
+      <circle class="be-sclera" cx="433.47" cy="155.46" r="110.46" />
+      <circle class="be-pupil" cx="476.28" cy="152.87" r="48.57" />
+      <circle class="be-highlight" cx="497.51" cy="137.48" r="12.36" />
+    </g>
   </svg>
 </span>
 
 <style>
   .blinking-eyes {
     display: inline-block;
-    width: 1.5em;
-    height: 1.5em;
+    width: 2em;
+    height: 1em;
     vertical-align: -0.225em;
     line-height: 0;
   }
@@ -61,34 +73,32 @@ const { interval = '2s', label } = Astro.props;
     height: 100%;
   }
 
-  /* Sclera = the visible "white" of the eye. Filled with --card so it
-   * stays pure white against any reasonable surface (the gray --muted
-   * background of the Tweet/Quote/Callout cards, the white --card of
-   * prose sections, the textured page background). Outlined in
-   * currentColor so the eye reads as a defined shape even on a
-   * --card-on-card surface where the fill blends in.
-   *
-   * vector-effect: non-scaling-stroke keeps the outline at a constant
-   * pixel width when the eye scales down to blink — without it, the
-   * stroke would compress along with the shape and disappear at the
-   * blink's lowest point. */
-  .be-sclera {
-    fill: var(--card);
-    stroke: currentColor;
-    stroke-width: 0.6;
-    vector-effect: non-scaling-stroke;
-  }
-  .be-iris {
+  /* Cartoon-eye palette. Rim and pupil ride currentColor so the glyph
+   * tints with surrounding text (and the closed-eye line stays
+   * readable on light AND dark surfaces). Sclera and highlight use
+   * --card so the eye reads as pure white against the gray
+   * Quote/Tweet/Callout cards, the white prose --card, and the
+   * textured page background. */
+  .be-rim {
     fill: currentColor;
   }
+  .be-sclera {
+    fill: var(--card);
+  }
+  .be-pupil {
+    fill: currentColor;
+  }
+  .be-highlight {
+    fill: var(--card);
+  }
 
-  /* Both sclera and iris share the same animation. transform-box:
-   * fill-box anchors each ellipse's transform-origin to its own
-   * bounding box, so each eye closes from both top AND bottom toward
-   * its own center. Since the sclera and iris of one eye share a
-   * center (cx, cy), they collapse in lockstep. */
-  .be-sclera,
-  .be-iris {
+  /* Each eye's four circles live inside a <g> so the whole eye
+   * collapses around one shared center. transform-box: fill-box
+   * anchors the <g>'s transform-origin to its own bounding box;
+   * transform-origin: center then puts the origin at the eye's
+   * geometric center. Both eyes share the same animation and timing,
+   * so they blink in sync. */
+  .be-eye {
     transform-box: fill-box;
     transform-origin: center;
     animation: be-blink var(--be-interval, 2s) infinite;
@@ -114,8 +124,7 @@ const { interval = '2s', label } = Astro.props;
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .be-sclera,
-    .be-iris {
+    .be-eye {
       animation: none;
     }
   }

--- a/src/components/BlinkingEyes.astro
+++ b/src/components/BlinkingEyes.astro
@@ -1,0 +1,122 @@
+---
+// Inline blinking-eyes glyph. Sits on the text baseline like an emoji,
+// scales with surrounding font-size (1em), and inherits the text color
+// via currentColor. Self-contained: vector + CSS keyframe, no JS, no
+// external assets. Respects prefers-reduced-motion per DESIGN.md's
+// motion rule.
+//
+// Each eye is two layered ellipses: an outlined sclera (the "white"
+// of the eye, filled with --card so it stays visibly lighter than any
+// surface the glyph lands on, outlined in currentColor), and an iris
+// filled in currentColor inside it. Both layers share the same blink
+// keyframes and the same transform-origin per eye, so the WHOLE eye
+// closes together — sclera and iris collapse in lockstep to a thin
+// horizontal line. Cadence loosely tuned to a brisk human blink rate
+// (~30/min on a 2s default cycle).
+
+interface Props {
+  /** CSS time string for the full blink cycle. Lower = blinks more
+   *  often. Default: "2s". */
+  interval?: string;
+  /** Optional accessible label. When provided, the icon is announced
+   *  via role="img" + aria-label. When omitted, the icon is
+   *  decorative and hidden from assistive tech. */
+  label?: string;
+}
+
+const { interval = '2s', label } = Astro.props;
+---
+
+<span
+  class="blinking-eyes"
+  style={`--be-interval: ${interval}`}
+  role={label ? 'img' : undefined}
+  aria-label={label}
+  aria-hidden={label ? undefined : 'true'}
+>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    focusable="false"
+    aria-hidden="true"
+  >
+    <ellipse class="be-sclera" cx="7" cy="12" rx="2.5" ry="3.5" />
+    <ellipse class="be-iris" cx="7" cy="12" rx="1.8" ry="1.8" />
+    <ellipse class="be-sclera" cx="17" cy="12" rx="2.5" ry="3.5" />
+    <ellipse class="be-iris" cx="17" cy="12" rx="1.8" ry="1.8" />
+  </svg>
+</span>
+
+<style>
+  .blinking-eyes {
+    display: inline-block;
+    width: 1.5em;
+    height: 1.5em;
+    vertical-align: -0.225em;
+    line-height: 0;
+  }
+  .blinking-eyes svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  /* Sclera = the visible "white" of the eye. Filled with --card so it
+   * stays pure white against any reasonable surface (the gray --muted
+   * background of the Tweet/Quote/Callout cards, the white --card of
+   * prose sections, the textured page background). Outlined in
+   * currentColor so the eye reads as a defined shape even on a
+   * --card-on-card surface where the fill blends in.
+   *
+   * vector-effect: non-scaling-stroke keeps the outline at a constant
+   * pixel width when the eye scales down to blink — without it, the
+   * stroke would compress along with the shape and disappear at the
+   * blink's lowest point. */
+  .be-sclera {
+    fill: var(--card);
+    stroke: currentColor;
+    stroke-width: 0.6;
+    vector-effect: non-scaling-stroke;
+  }
+  .be-iris {
+    fill: currentColor;
+  }
+
+  /* Both sclera and iris share the same animation. transform-box:
+   * fill-box anchors each ellipse's transform-origin to its own
+   * bounding box, so each eye closes from both top AND bottom toward
+   * its own center. Since the sclera and iris of one eye share a
+   * center (cx, cy), they collapse in lockstep. */
+  .be-sclera,
+  .be-iris {
+    transform-box: fill-box;
+    transform-origin: center;
+    animation: be-blink var(--be-interval, 2s) infinite;
+  }
+
+  /* Open for most of the cycle, snap closed with ease-in, ease back
+   * open. At the 2s default that's ~100ms close / ~150ms open / rest
+   * held open — close/open scale proportionally if the cycle is
+   * lengthened or shortened via the interval prop. */
+  @keyframes be-blink {
+    0%,
+    87.5% {
+      transform: scaleY(1);
+      animation-timing-function: ease-in;
+    }
+    92.5% {
+      transform: scaleY(0.08);
+      animation-timing-function: ease-out;
+    }
+    100% {
+      transform: scaleY(1);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .be-sclera,
+    .be-iris {
+      animation: none;
+    }
+  }
+</style>

--- a/src/components/Callout.astro
+++ b/src/components/Callout.astro
@@ -1,0 +1,74 @@
+---
+// Callout — emphasis block for the author's own voice. Sets a passage
+// apart from the surrounding body prose without attribution. For
+// external attributed quotations, use <Quote /> instead.
+//
+// The visual differentiation is purely typographic + spatial —
+// weight (Aileron Black), scale (h4 → h3 step at sm+), and rhythm
+// (generous vertical padding). No surface, no shadow, no border-left
+// blockquote variant. Aligns with DESIGN.md's rule that hierarchy
+// comes from typography and rhythm, not decoration.
+---
+
+<aside class="not-prose callout">
+  <slot />
+</aside>
+
+<style>
+  .callout {
+    margin: 2.5rem 0;
+    padding: 1.5rem;
+    background: var(--muted);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    text-align: center;
+    font-family: var(--font-family-sans);
+    font-size: var(--role-h4-size);
+    line-height: 1.35;
+    letter-spacing: var(--role-h4-tracking);
+    font-weight: var(--role-h4-weight);
+    color: var(--foreground);
+  }
+
+  /* Short decorative rules above and below. They mark the callout as
+   * lifted out of the surrounding prose without claiming the visual
+   * weight of a section card. 1px --foreground at reduced opacity
+   * keeps the monochrome palette intact. */
+  .callout::before,
+  .callout::after {
+    content: '';
+    display: block;
+    width: 2rem;
+    height: 1px;
+    background: var(--foreground);
+    opacity: 0.4;
+    margin: 0 auto;
+  }
+  .callout::before {
+    margin-bottom: 1.25rem;
+  }
+  .callout::after {
+    margin-top: 1.25rem;
+  }
+
+  /* MDX may wrap inline text in <p>. Strip the default prose-style
+   * margins so the callout's own rhythm controls spacing. */
+  .callout :global(p) {
+    margin: 0 0 0.5rem;
+  }
+  .callout :global(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  /* At sm+ the prose column gives the callout room to step up to the
+   * h3 scale. The size jump matches the design system's step-snap
+   * pattern for display elements. */
+  @media (min-width: 640px) {
+    .callout {
+      font-size: var(--role-h3-size);
+      line-height: 1.3;
+      letter-spacing: var(--role-h3-tracking);
+      padding: 2rem;
+    }
+  }
+</style>

--- a/src/components/OpinionatedSpectrum.astro
+++ b/src/components/OpinionatedSpectrum.astro
@@ -1,0 +1,127 @@
+---
+// Diagram for §"Take a Stand" in more-than-chatbots.mdx. Visualizes
+// the unopinionated → opinionated spectrum across three
+// product-design dimensions: Powerful → Purposeful, Flexible →
+// Simple, General → Specific.
+//
+// Per DESIGN.md (~/git/ALRubinger/aileron/design/DESIGN.md):
+//   - Monochrome only. currentColor + var(--muted-foreground) +
+//     var(--border). No chromatic accent. The wedge metaphor (a
+//     shape) carries the meaning instead of color.
+//   - Typography is the hero. Aileron Black row labels in
+//     --foreground; ui-label-style tracked-out caps for the
+//     meta-axis in --muted-foreground. Weight + scale contrast does
+//     the work color would do elsewhere.
+//   - 1px lines only — the divider matches the spec's border rule.
+//   - Light direction n/a: no shadows.
+//
+// Each row's triangular wedge tapers from a wide left edge ("wide
+// possibility space") to a single point on the right ("focused
+// intent"). The shape narrows in lockstep with the labels' framing:
+// open → committed.
+//
+// Inline SVG so the figure inherits page font (Aileron via the
+// shared design tokens) and tints with surrounding text via the
+// monochrome tokens — reads correctly in both light and dark mode
+// without any per-mode rules.
+---
+
+<figure class="opinionated-spectrum">
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 720 300"
+    role="img"
+    aria-labelledby="oss-title oss-desc"
+    preserveAspectRatio="xMidYMid meet"
+  >
+    <title id="oss-title">The opinionated-software spectrum</title>
+    <desc id="oss-desc">
+      Three product-design dimensions plotted from unopinionated
+      (left) to opinionated (right): Powerful narrows to Purposeful,
+      Flexible narrows to Simple, and General narrows to Specific.
+      Each row is a triangular wedge that starts wide on the left and
+      tapers to a point on the right, mirroring the shift from open
+      possibility to focused intent.
+    </desc>
+
+    <g class="oss-meta">
+      <text x="0" y="18" dominant-baseline="middle">UNOPINIONATED</text>
+      <text x="720" y="18" dominant-baseline="middle" text-anchor="end">OPINIONATED</text>
+      <line x1="170" y1="18" x2="531" y2="18" />
+      <path d="M531 12 L545 18 L531 24 Z" />
+    </g>
+
+    <line class="oss-divider" x1="0" y1="44" x2="720" y2="44" />
+
+    <g class="oss-row">
+      <text x="0" y="110" dominant-baseline="middle">Powerful</text>
+      <text x="720" y="110" dominant-baseline="middle" text-anchor="end">Purposeful</text>
+      <path class="oss-wedge" d="M170 102 L545 110 L170 118 Z" />
+    </g>
+
+    <g class="oss-row">
+      <text x="0" y="180" dominant-baseline="middle">Flexible</text>
+      <text x="720" y="180" dominant-baseline="middle" text-anchor="end">Simple</text>
+      <path class="oss-wedge" d="M170 172 L545 180 L170 188 Z" />
+    </g>
+
+    <g class="oss-row">
+      <text x="0" y="250" dominant-baseline="middle">General</text>
+      <text x="720" y="250" dominant-baseline="middle" text-anchor="end">Specific</text>
+      <path class="oss-wedge" d="M170 242 L545 250 L170 258 Z" />
+    </g>
+  </svg>
+</figure>
+
+<style>
+  .opinionated-spectrum {
+    margin: 2rem 0;
+    color: var(--foreground);
+  }
+  .opinionated-spectrum svg {
+    display: block;
+    width: 100%;
+    height: auto;
+    font-family: var(--font-family-sans);
+  }
+
+  /* Meta-axis: tracked-out caps in --muted-foreground. A small frame
+   * for the diagram — establishes the left → right reading
+   * direction without claiming visual weight. */
+  .oss-meta text {
+    font-size: 16px;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+    fill: var(--muted-foreground);
+  }
+  .oss-meta line {
+    stroke: var(--muted-foreground);
+    stroke-width: 1.5;
+  }
+  .oss-meta path {
+    fill: var(--muted-foreground);
+  }
+
+  /* 1px divider per DESIGN.md's "no thicker than 1px" border rule. */
+  .oss-divider {
+    stroke: var(--border);
+    stroke-width: 1;
+  }
+
+  /* Row labels = the hero. Aileron Black at h3-ish scale (sized in
+   * viewBox units so the SVG scales as a whole). Weight + scale
+   * contrast carry the hierarchy; the wedge supports them. */
+  .oss-row text {
+    font-size: 28px;
+    font-weight: 800;
+    letter-spacing: -0.015em;
+    fill: var(--foreground);
+  }
+
+  /* Wedge: triangular taper from a wide left edge to a point on the
+   * right. --muted-foreground so the shape sits behind the labels,
+   * not in front of them. The narrowing IS the spectrum metaphor. */
+  .oss-wedge {
+    fill: var(--muted-foreground);
+  }
+</style>

--- a/src/components/Point.astro
+++ b/src/components/Point.astro
@@ -1,0 +1,76 @@
+---
+// Point — one numbered idea inside <Points>. The numeral is
+// rendered by a CSS counter on the parent container, so the value
+// matches DOM order and authors never need to pass an index.
+//
+// Visual treatment per DESIGN.md: oversized Aileron Black numeral
+// (the hero), 1px hairline rule, body prose below. No surface, no
+// color — scale + weight + spatial rhythm carry the emphasis.
+---
+
+<div class="point">
+  <span class="point-number" aria-hidden="true"></span>
+  <div class="point-body">
+    <slot />
+  </div>
+</div>
+
+<style>
+  .point {
+    counter-increment: point;
+    display: flex;
+    flex-direction: column;
+    /* Slightly less than the surrounding column gap so the number,
+     * hairline, and body read as one unit rather than three rows. */
+    gap: 1rem;
+  }
+
+  /* Big numeral above a hairline rule — the editorial pull-quote
+   * pattern. decimal-leading-zero gives "01, 02, …" which reads as
+   * deliberate display at this scale; plain "1, 2" would feel like
+   * list-item leftovers. */
+  .point-number {
+    display: block;
+    font-family: var(--font-family-sans);
+    font-weight: var(--font-weight-black);
+    font-size: var(--text-5xl-size);
+    line-height: 1;
+    letter-spacing: var(--text-5xl-tracking);
+    color: var(--foreground);
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border);
+    font-variant-numeric: tabular-nums;
+  }
+  .point-number::before {
+    content: counter(point, decimal-leading-zero);
+  }
+
+  /* Body holds whatever the author wrote — a short phrase, a single
+   * sentence, or a small paragraph. body-lg gives the points a touch
+   * more presence than surrounding prose so the row reads as
+   * elevated content, without claiming heading weight. */
+  .point-body {
+    font-family: var(--font-family-sans);
+    font-size: var(--role-body-lg-size);
+    line-height: var(--role-body-lg-line-height);
+    letter-spacing: var(--role-body-lg-tracking);
+    font-weight: var(--role-body-lg-weight);
+    color: var(--foreground);
+  }
+  .point-body :global(p) {
+    margin: 0 0 0.5rem;
+  }
+  .point-body :global(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  /* At sm+ the prose column gives the numeral room to step up to
+   * the 6xl scale — matches the step-snap pattern other display
+   * elements use (see Quote.astro, h1). */
+  @media (min-width: 640px) {
+    .point-number {
+      font-size: var(--text-6xl-size);
+      letter-spacing: var(--text-6xl-tracking);
+    }
+  }
+</style>

--- a/src/components/Points.astro
+++ b/src/components/Points.astro
@@ -1,0 +1,45 @@
+---
+// Points — horizontal row of 2–5 numbered <Point> children used to
+// call out the big ideas of a passage. Each child auto-numbers in
+// DOM order via a CSS counter on this container, so authors don't
+// thread an index prop through every point.
+//
+// Per DESIGN.md (~/git/ALRubinger/aileron/design/DESIGN.md):
+//   - Monochrome only. No surface, no shadow — the typographic
+//     numeral and a 1px hairline carry the emphasis. Reaching for a
+//     muted card here would duplicate what scale + weight already do.
+//   - Hierarchy from typography and rhythm: oversized Aileron Black
+//     numbers above the body, generous gap between columns.
+//   - 1px borders only (the hairline under each numeral).
+//
+// Layout: CSS grid with `repeat(auto-fit, minmax(0, 1fr))` at sm+
+// so 2, 3, 4, or 5 children lay out evenly across the prose width
+// without per-count branching. Below sm the row collapses to a
+// single stacked column — at mobile widths a 4-up row of points
+// would shrink each idea to an unreadable sliver.
+---
+
+<div class="points not-prose">
+  <slot />
+</div>
+
+<style>
+  .points {
+    counter-reset: point;
+    margin: 2.5rem 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+
+  /* At sm+ the prose column has room for the horizontal row.
+   * minmax(0, 1fr) lets every column shrink equally so 4 or 5
+   * points still fit without one outsized column dominating. */
+  @media (min-width: 640px) {
+    .points {
+      grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+      gap: 2.5rem;
+      margin: 3rem 0;
+    }
+  }
+</style>

--- a/src/components/PostHeader.astro
+++ b/src/components/PostHeader.astro
@@ -27,7 +27,7 @@ if (imagePath && !heroImages[imagePath]) {
 
 <header class="post-header">
   <div class="post-header-text">
-    <h1 class="post-header-title">{title}</h1>
+    <h1 id="post-title" class="post-header-title">{title}</h1>
     <p class="post-header-date">
       Published on{' '}
       <b><time datetime={date.toISOString()}>{formatDateLong(date)}</time></b>

--- a/src/components/Quote.astro
+++ b/src/components/Quote.astro
@@ -33,14 +33,43 @@ const authorXUrl = authorXHandle
 // Accept the same shape z.coerce.date() accepts in the content
 // collection — a YYYY-MM-DD string parses as UTC midnight, which
 // pairs with formatDateLong's timeZone: 'UTC' so the displayed day
-// matches the authored day regardless of viewer locale.
+// matches the authored day regardless of viewer locale. Partial
+// strings (YYYY or YYYY-MM) downshift the display to match the
+// granularity the author supplied.
+const dateStr = typeof date === 'string' ? date : undefined;
+const precision: 'year' | 'month' | 'day' = dateStr
+  ? /^\d{4}$/.test(dateStr)
+    ? 'year'
+    : /^\d{4}-\d{2}$/.test(dateStr)
+      ? 'month'
+      : 'day'
+  : 'day';
 const dateObj = date
   ? date instanceof Date
     ? date
     : new Date(date)
   : undefined;
-const dateFormatted = dateObj ? formatDateLong(dateObj) : undefined;
-const dateIso = dateObj ? dateObj.toISOString() : undefined;
+const dateFormatted = dateObj
+  ? precision === 'year'
+    ? dateObj.toLocaleDateString('en-US', {
+        year: 'numeric',
+        timeZone: 'UTC',
+      })
+    : precision === 'month'
+      ? dateObj.toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'long',
+          timeZone: 'UTC',
+        })
+      : formatDateLong(dateObj)
+  : undefined;
+const dateIso = dateObj
+  ? precision === 'year'
+    ? dateObj.toISOString().slice(0, 4)
+    : precision === 'month'
+      ? dateObj.toISOString().slice(0, 7)
+      : dateObj.toISOString().slice(0, 10)
+  : undefined;
 ---
 
 <figure class="not-prose quote-callout">

--- a/src/components/Quote.astro
+++ b/src/components/Quote.astro
@@ -1,0 +1,251 @@
+---
+import { formatDateLong } from '@/lib/posts';
+
+interface Props {
+  quote?: string;
+  url: string;
+  articleName: string;
+  publicationName: string;
+  authorName: string;
+  /** ISO date string like "2026-06-07" (same shape the frontmatter
+   *  accepts) or a JS Date. Optional. */
+  date?: string | Date;
+  /** Author's X (Twitter) handle, with or without leading "@".
+   *  Renders an X-logo link beside the author name. Optional. */
+  authorX?: string;
+}
+
+const {
+  quote,
+  url,
+  articleName,
+  publicationName,
+  authorName,
+  date,
+  authorX,
+} = Astro.props;
+
+const authorXHandle = authorX?.replace(/^@/, '');
+const authorXUrl = authorXHandle
+  ? `https://x.com/${authorXHandle}`
+  : undefined;
+
+// Accept the same shape z.coerce.date() accepts in the content
+// collection — a YYYY-MM-DD string parses as UTC midnight, which
+// pairs with formatDateLong's timeZone: 'UTC' so the displayed day
+// matches the authored day regardless of viewer locale.
+const dateObj = date
+  ? date instanceof Date
+    ? date
+    : new Date(date)
+  : undefined;
+const dateFormatted = dateObj ? formatDateLong(dateObj) : undefined;
+const dateIso = dateObj ? dateObj.toISOString() : undefined;
+---
+
+<figure class="not-prose quote-callout">
+  <span class="quote-callout-mark quote-callout-mark-open" aria-hidden="true">
+    &ldquo;
+  </span>
+
+  <blockquote class="quote-callout-body" cite={url}>
+    {quote ? <p>{quote}</p> : <slot />}
+  </blockquote>
+
+  <span class="quote-callout-mark quote-callout-mark-close" aria-hidden="true">
+    &rdquo;
+  </span>
+
+  <figcaption class="quote-callout-cite">
+    <span class="quote-callout-author">
+      {authorName}
+      {authorXUrl && (
+        <a
+          href={authorXUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`${authorName} on X`}
+          class="quote-callout-author-x no-arrow"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width="14"
+            height="14"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+          </svg>
+        </a>
+      )}
+    </span>
+    <span class="quote-callout-source">
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="quote-callout-article no-arrow"
+      >
+        <cite>{articleName}</cite>
+        <span aria-hidden="true"> ↗</span>
+      </a>
+      <span class="quote-callout-separator" aria-hidden="true">·</span>
+      <span class="quote-callout-publication">{publicationName}</span>
+      {dateFormatted && (
+        <>
+          <span class="quote-callout-separator" aria-hidden="true">·</span>
+          <time class="quote-callout-date" datetime={dateIso}>
+            {dateFormatted}
+          </time>
+        </>
+      )}
+    </span>
+  </figcaption>
+</figure>
+
+<style>
+  /* Pull-quote callout. Inset on the white prose-section card via a
+   * muted background, border, and rounded corners — matching the
+   * PostHeader treatment so all "lifted content" blocks share one
+   * surface vocabulary. */
+  .quote-callout {
+    margin: 2rem 0;
+    padding: 1.5rem;
+    background: var(--muted);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0;
+  }
+
+  /* Oversized quote marks frame the body vertically. Open hangs at
+   * top-left, close hangs at bottom-right, mirroring how a printed
+   * pull-quote sets quotation glyphs as architecture rather than
+   * punctuation. Aileron Black at --text-5xl with tight line-height. */
+  .quote-callout-mark {
+    display: block;
+    font-family: var(--font-family-sans);
+    font-weight: var(--font-weight-black);
+    font-size: var(--text-5xl-size);
+    line-height: 0.6;
+    color: var(--foreground);
+    opacity: 0.18;
+    user-select: none;
+  }
+  .quote-callout-mark-open {
+    text-align: left;
+    margin-bottom: 0.5rem;
+  }
+  .quote-callout-mark-close {
+    text-align: right;
+    margin-top: 0.5rem;
+    /* The close mark is a smart-quote glyph; nudge it onto the baseline
+     * so the descender doesn't visually drift below the row. */
+    transform: translateY(0.35em);
+  }
+
+  /* Body in the lead role, italicized to read as a quotation without
+   * leaning on quote glyphs for that signal (the big marks above do
+   * the work). Slightly tighter leading than body prose since each
+   * line is short. */
+  .quote-callout-body {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-family: var(--font-family-sans);
+    font-size: var(--role-lead-size);
+    line-height: 1.55;
+    letter-spacing: var(--role-lead-tracking);
+    font-weight: var(--role-lead-weight);
+    font-style: italic;
+    color: var(--foreground);
+  }
+  .quote-callout-body :global(p) {
+    margin: 0 0 0.75rem;
+  }
+  .quote-callout-body :global(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  /* Attribution block. A thin --border rule separates it from the
+   * body. Author in ui-label (Black 800) for weight contrast against
+   * the italic Regular quote. Article and publication in body-sm. */
+  .quote-callout-cite {
+    margin-top: 1.25rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-style: normal;
+  }
+  .quote-callout-author {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: var(--font-family-sans);
+    font-size: var(--role-ui-label-size);
+    line-height: var(--role-ui-label-line-height);
+    font-weight: var(--role-ui-label-weight);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--foreground);
+  }
+  .quote-callout-author-x {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--muted-foreground);
+    text-decoration: none;
+    transition: color 0.15s ease;
+  }
+  .quote-callout-author-x:hover {
+    color: var(--foreground);
+  }
+  .quote-callout-source {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem;
+    font-family: var(--font-family-sans);
+    font-size: var(--role-body-sm-size);
+    line-height: var(--role-body-sm-line-height);
+    color: var(--muted-foreground);
+  }
+  .quote-callout-article {
+    color: var(--foreground);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-thickness: 1px;
+  }
+  .quote-callout-article cite {
+    font-style: italic;
+  }
+  .quote-callout-article:hover {
+    opacity: 0.75;
+  }
+  .quote-callout-separator {
+    color: var(--muted-foreground);
+    opacity: 0.6;
+  }
+  .quote-callout-publication {
+    color: var(--muted-foreground);
+  }
+  .quote-callout-date {
+    color: var(--muted-foreground);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* On wider viewports the muted card breathes more and the quote
+   * marks gain a bit more presence. */
+  @media (min-width: 640px) {
+    .quote-callout {
+      padding: 2rem;
+    }
+    .quote-callout-mark {
+      font-size: var(--text-6xl-size);
+    }
+  }
+</style>

--- a/src/components/Sidebar.svelte
+++ b/src/components/Sidebar.svelte
@@ -116,7 +116,7 @@
       onclick={() => (mobileOpen = false)}
     >
       <Calendar size={16} class="shrink-0" />
-      Tell me about your team
+      Book ALR for Customer Discovery
     </a>
   </div>
 </aside>

--- a/src/components/TableOfContents.svelte
+++ b/src/components/TableOfContents.svelte
@@ -7,11 +7,17 @@
     depth: number;
   };
 
-  let { headings = [] }: { headings?: Heading[] } = $props();
+  let { title, headings = [] }: { title?: string; headings?: Heading[] } = $props();
   let activeSlug = $state('');
 
-  // Filter to h2 and h3 only
-  const tocHeadings = $derived(headings.filter(h => h.depth >= 2 && h.depth <= 3));
+  // Prepend the post title as a depth-1 entry pointing at the h1's id,
+  // then filter to the title + h2/h3 so the TOC mirrors the page's
+  // top-level structure.
+  const TITLE_SLUG = 'post-title';
+  const tocHeadings = $derived([
+    ...(title ? [{ slug: TITLE_SLUG, text: title, depth: 1 }] : []),
+    ...headings.filter(h => h.depth >= 2 && h.depth <= 3),
+  ]);
 
   onMount(() => {
     const elements = tocHeadings

--- a/src/components/Tweet.astro
+++ b/src/components/Tweet.astro
@@ -1,0 +1,299 @@
+---
+import { fetchTweet } from '@/lib/tweets';
+import { formatDate } from '@/lib/posts';
+
+interface Props {
+  url: string;
+}
+
+const { url } = Astro.props;
+
+// Fetched at build time from the public X syndication endpoint.
+// Throws (failing the build) when the tweet is deleted, the account
+// is protected, or the endpoint is unreachable — so authors get a
+// loud, source-located error rather than a silently empty card.
+const tweet = await fetchTweet(url);
+
+const { author, text, createdAt, likes, replies } = tweet;
+const profileUrl = `https://x.com/${author.handle}`;
+const dateFormatted = formatDate(new Date(createdAt));
+
+const compact = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+});
+const display = (n: number): string =>
+  n < 10_000 ? n.toLocaleString('en-US') : compact.format(n);
+const full = (n: number): string => n.toLocaleString('en-US');
+
+const initials = author.name
+  .split(/\s+/)
+  .filter(Boolean)
+  .slice(0, 2)
+  .map((part) => part[0]?.toUpperCase() ?? '')
+  .join('');
+---
+
+<figure class="not-prose tweet-card">
+  <header class="tweet-card-header">
+    <a
+      href={profileUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={`${author.name} on X`}
+      class="tweet-card-avatar no-arrow"
+    >
+      {author.avatar ? (
+        <img
+          src={author.avatar}
+          alt=""
+          width="48"
+          height="48"
+          loading="lazy"
+          referrerpolicy="no-referrer"
+          class="tweet-card-avatar-img"
+        />
+      ) : (
+        <span class="tweet-card-avatar-fallback" aria-hidden="true">
+          {initials || '@'}
+        </span>
+      )}
+    </a>
+
+    <div class="tweet-card-identity">
+      <a
+        href={profileUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="tweet-card-name no-arrow"
+      >
+        {author.name}
+        {author.verified && (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 22 22"
+            width="14"
+            height="14"
+            aria-label="Verified"
+            class="tweet-card-verified"
+          >
+            <path
+              fill="currentColor"
+              d="M20.396 11c-.018-.646-.215-1.275-.57-1.816-.354-.54-.852-.972-1.438-1.246.223-.607.27-1.264.14-1.897-.131-.634-.437-1.218-.882-1.687-.47-.445-1.053-.751-1.687-.882-.633-.13-1.29-.083-1.897.14-.273-.587-.704-1.086-1.245-1.44S11.647 1.62 11 1.604c-.646.017-1.273.213-1.813.568s-.969.854-1.24 1.44c-.608-.223-1.267-.272-1.902-.14-.635.13-1.22.436-1.69.882-.445.47-.749 1.055-.878 1.688-.13.633-.08 1.29.144 1.896-.587.274-1.087.705-1.443 1.245-.356.541-.555 1.17-.574 1.817.02.647.218 1.276.574 1.817.356.54.856.972 1.443 1.245-.224.606-.274 1.263-.144 1.896.13.634.433 1.218.877 1.688.47.443 1.054.747 1.687.878.633.132 1.29.084 1.897-.136.274.586.705 1.084 1.246 1.439.54.354 1.17.551 1.816.569.647-.016 1.276-.213 1.817-.567s.972-.854 1.245-1.44c.604.239 1.266.296 1.903.164.636-.132 1.22-.447 1.68-.907.46-.46.776-1.044.908-1.681s.075-1.299-.165-1.903c.586-.273 1.084-.705 1.439-1.246.354-.54.551-1.17.569-1.816zM9.662 14.85l-3.429-3.428 1.293-1.302 2.072 2.072 4.4-4.794 1.347 1.246z"
+            />
+          </svg>
+        )}
+      </a>
+      <a
+        href={profileUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="tweet-card-handle no-arrow"
+      >@{author.handle}</a>
+    </div>
+
+    <a
+      href={tweet.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="tweet-card-source no-arrow"
+      aria-label="View original post on X"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        width="18"
+        height="18"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+      </svg>
+    </a>
+  </header>
+
+  <blockquote class="tweet-card-body" cite={tweet.url}>
+    {text}
+  </blockquote>
+
+  <a
+    href={tweet.url}
+    target="_blank"
+    rel="noopener noreferrer"
+    class="tweet-card-date no-arrow"
+  >
+    <time datetime={createdAt}>{dateFormatted}</time>
+  </a>
+
+  <footer class="tweet-card-stats">
+    <span
+      class="tweet-card-stat"
+      title={`${full(likes)} likes`}
+      aria-label={`${full(likes)} likes`}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        width="16"
+        height="16"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+      </svg>
+      <span>{display(likes)}</span>
+    </span>
+    <span
+      class="tweet-card-stat"
+      title={`${full(replies)} replies`}
+      aria-label={`${full(replies)} replies`}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        width="16"
+        height="16"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+      </svg>
+      <span>{display(replies)}</span>
+    </span>
+  </footer>
+</figure>
+
+<style>
+  .tweet-card {
+    margin: 1.5rem 0;
+    padding: 1.25rem 1.25rem 1rem;
+    background: var(--muted);
+    color: var(--foreground);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    font-family: var(--font-family-sans);
+    line-height: 1.5;
+    max-width: 100%;
+  }
+
+  .tweet-card-header {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .tweet-card-avatar {
+    display: inline-flex;
+    width: 48px;
+    height: 48px;
+    border-radius: 9999px;
+    overflow: hidden;
+    background: var(--muted);
+    border: 1px solid var(--border);
+    text-decoration: none;
+    color: inherit;
+    flex: none;
+  }
+  .tweet-card-avatar-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .tweet-card-avatar-fallback {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    font-weight: 700;
+    font-size: 1rem;
+    color: var(--muted-foreground);
+  }
+
+  .tweet-card-identity {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    line-height: 1.2;
+    gap: 0.125rem;
+  }
+  .tweet-card-name {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-weight: 700;
+    font-size: 0.9375rem;
+    color: var(--foreground);
+    text-decoration: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .tweet-card-name:hover { text-decoration: underline; }
+  .tweet-card-verified {
+    color: var(--primary);
+    flex: none;
+  }
+  .tweet-card-handle {
+    font-size: 0.875rem;
+    color: var(--muted-foreground);
+    text-decoration: none;
+  }
+  .tweet-card-handle:hover { color: var(--foreground); }
+
+  .tweet-card-source {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--muted-foreground);
+    text-decoration: none;
+    transition: color 0.15s ease;
+  }
+  .tweet-card-source:hover { color: var(--foreground); }
+
+  .tweet-card-body {
+    margin: 1rem 0 0;
+    padding: 0;
+    border: 0;
+    font-size: 1rem;
+    color: var(--foreground);
+    white-space: pre-wrap;
+  }
+
+  .tweet-card-date {
+    display: inline-block;
+    margin-top: 0.875rem;
+    font-size: 0.8125rem;
+    color: var(--muted-foreground);
+    text-decoration: none;
+  }
+  .tweet-card-date:hover { color: var(--foreground); }
+
+  .tweet-card-stats {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1.25rem;
+    margin-top: 0.875rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.8125rem;
+    color: var(--muted-foreground);
+  }
+  .tweet-card-stat {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+  }
+  .tweet-card-stat svg { flex: none; }
+</style>

--- a/src/content/posts/better-than-chatbots.mdx
+++ b/src/content/posts/better-than-chatbots.mdx
@@ -1,88 +1,822 @@
 ---
 title: We Deserve More Than Chatbots
-description: First principles, plainly stated.
+description: They're powerful, they're open-ended, they're addictive. For most work, it's time to move on.
 date: 2026-06-07
 author: alrubinger
 ---
 
-{/* PREAMBLE
-    Three stances that set the ground we're standing on.
-    Not arguments — declarations. The third is load-bearing:
-    it's the *why* first principles matter at all right now. */}
+{/* WORKING DRAFT — two sections:
+    (1) themes + emerging narrative, with evidence inline per theme
+    (2) the raw dictated transcript, lightly paragraph-broken */}
 
-We don't chase trends. The AI moment is real, but most of what gets
-built in moments like this is built *for* the moment, not for the
-people in it. We'd rather build something that's still right in five
-years than something that's loud this week.
+## Themes and emerging narrative
 
-We're not trying to fit cleanly into the hype cycle. We're not
-positioning against an AGI timeline or a benchmark or a feud between
-two labs. We'd like to be easily classifiable, but we're not going
-to round ourselves off to make the slide deck simpler.
+{/* Each theme leads with the argument, then carries its evidence
+    inline. ★ marks the load-bearing source for that point.
+    "Counter / nuance" sources are flagged where they push back. */}
 
-And honestly: none of us in this industry — Aileron included — are
-moving at a pace any social, economic, or regulatory system was built
-to absorb. The rules are lagging. The norms are lagging. The markets
-are lagging. That's not an excuse to wait. It's the reason the
-principles we hold ourselves to matter more right now, not less.
+### 1. The arrival story — what chatbots gave us
 
-{/* BRIDGE — drop this line if the preamble lands on its own. */}
+- Cultural delight: a machine that finally talks back in something
+  believably human.
+- The blinking cursor as new paradigm: conversational search replacing
+  raw-results search.
+- Agents added tools: email, calendar, Drive, internal back-end
+  systems. A connector ecosystem appeared.
+- The big unlock: anyone can dream up custom software, custom
+  dashboards, custom workflows — by prompt.
+- The kicker — and the pivot into theme 2 — is in the
+  transcript's own words: *"anything that we can dream up, we can
+  put into a chatbot. And provided that we know how to prompt it."*
+  That "provided" is doing a lot of work. The rest of the post is
+  about what's hiding underneath it.
 
-Three of them. Here's what each one means.
+> **Evidence — the arrival is real:**
+>
+> - [McKinsey, *State of AI in 2025*](https://www.mckinsey.com/capabilities/quantumblack/our-insights/the-state-of-ai) —
+>   88% of organizations now use AI regularly. The paradigm is not
+>   hype anymore; it's installed base.
 
-## Trust
+### 2. The hidden cost — a tax on knowledge work
 
-{/* What this section does: declares Trust as the floor, in language
-    anyone gets on the first read.
-    Quotable spine: "structural, not asked-for." */}
+> *"We're seeing everything through the lens of this prompt, this
+> empty blinking cursor we can type anything through… In addition to
+> doing your job, now you need to get good at these new tools and
+> you need to stay plugged in, and you need to be learning with
+> routine the latest that's coming down the pike, and that's
+> exhausting."*
 
-Your stuff stays yours. Nobody else sees what you didn't choose to
-share, and nobody can break in. This is the floor everything else
-rests on — get it wrong and nothing else we build matters. The job
-isn't to convince you to trust us. It's to build the thing so the
-trust is structural, not asked-for.
+- We've asked every knowledge worker to "get good" at chatbots.
+- The simplest-looking interface is deceptively complex: configure
+  backends, manage skills, track vendors, absorb new features
+  constantly.
+- That's a *second job* layered on top of the first. *"We've
+  overwhelmed the public with more information than they can absorb
+  when remember that it's their job to principally do their job."*
+- Two responses, oversimplified — but careful here, the obvious
+  framing is wrong:
+  - The **enthusiasts** — first in the fray, leading the org, doing
+    the meta-work of staying current.
+  - The **laggards** — heads-down on actual work, no time for the
+    meta.
+- The cruel twist (and the strongest empirical finding in the space):
+  the laggards are exactly the people who would gain the *most* in
+  measurable capability if they adopted. The divide we see in the
+  wild is at the *adoption* layer, not the *capability* layer.
+- Which means the chatbot interface isn't just an aesthetic
+  complaint. It's the toll booth between the people who would gain
+  most from AI and the gains themselves.
 
-## Value
+> **Evidence — gains skew to novices (the empirical inversion).** The
+> finding originated in 2023 and has now been replicated and
+> peer-reviewed across multiple domains in 2025–2026:
+>
+> - **★ [Brynjolfsson, Li & Raymond, *QJE* May 2025](https://academic.oup.com/qje/article/140/2/889/7990658)** —
+>   The canonical citation. The 2023 NBER paper formally published in
+>   *Quarterly Journal of Economics*: 5,172 support agents,
+>   bottom-quintile workers gained 34–36%, top performers near zero.
+> - **★ [Cui, Demirer, Peng et al., *Management Science* 2025/26](https://pubsonline.informs.org/doi/10.1287/mnsc.2025.00535)** —
+>   Three RCTs across Microsoft, Accenture, and a Fortune 100 firm;
+>   4,867 software developers; AI coding assistant. 26% average
+>   completed-task increase. Less experienced developers had *both*
+>   higher adoption *and* larger productivity gains. Direct
+>   replication of the pattern in coding.
+> - **★ [Dell'Acqua et al., "Navigating the Jagged Technological Frontier," *Organization Science* March 2026](https://pubsonline.informs.org/doi/10.1287/orsc.2025.21838)** —
+>   758 BCG consultants, GPT-4. Inside-frontier tasks: 30–40% quality
+>   gains, bottom-half performers showed "substantially larger
+>   relative gains." Outside-frontier: correctness *dropped* 19pp for
+>   AI users. Same compression pattern, with task-type caveat.
+> - [Fruits & Stout, *AI, Productivity, and Labor Markets* (ICLE Feb 2026)](https://laweconcenter.org/resources/ai-productivity-and-labor-markets-a-review-of-the-empirical-evidence/) —
+>   Meta-review of micro-level RCTs. Skill compression is the
+>   dominant finding across studies. Notes Merali (2024): lower-skill
+>   translators gained ~4× more than higher-skill peers.
+> - [Stray et al., longitudinal Copilot case study, arXiv Jan 2026](https://arxiv.org/abs/2509.20353) —
+>   Norwegian public-sector developers, commit-level metrics +
+>   interviews. Greatest gains among less experienced devs; seniors
+>   muted or mixed.
+> - [Noy & Zhang, *Science* 2023](https://www.science.org/doi/10.1126/science.adh2586) —
+>   The original 453-person RCT. Foundational but now corroborated by
+>   newer, larger, peer-reviewed work; cite for lineage, not as the
+>   sole prop.
+>
+> **Complication worth owning — the novice-gains-more claim is
+> task-conditional, not universal:**
+>
+> - **★ [METR — "Measuring the Impact of Early-2025 AI on Experienced Open-Source Developer Productivity," July 2025](https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/)** —
+>   RCT, 16 experienced open-source developers, 246 real repository
+>   tasks. Allowing AI *increased* completion time by 19%. Developers
+>   predicted 20% savings — they were directionally wrong. Mechanism:
+>   deep repo familiarity, large legacy codebases, low AI acceptance
+>   rate (~44%). The sharper read: AI helps novices on *standardized*
+>   tasks; it can actively harm experts on *complex, idiosyncratic*
+>   work. The post should acknowledge this rather than overclaim.
+> - [Riedl & Bogert, "Effects of AI Feedback on Learning, the Skill Gap, and Intellectual Diversity," arXiv Sep 2024](https://arxiv.org/abs/2409.18660) —
+>   52,000 chess players, 42 platform natural experiments. Higher-skill
+>   players seek AI feedback strategically; lower-skill players seek
+>   it after wins (counterproductive). Over time, AI access *widened*
+>   the skill gap rather than compressing it. About *learning*
+>   dynamics, not task completion — but worth knowing.
+>
+> **Evidence — the adoption tax is real and falls hardest on the
+> laggards:**
+>
+> - **★ [BCG, *AI at Work 2025*](https://www.bcg.com/publications/2025/ai-at-work-momentum-builds-but-gaps-remain)** —
+>   10,600+ workers, 11 countries. Only 36% say training is enough;
+>   18% of regular AI users got *no training at all*; 54% would use
+>   unauthorized tools ("shadow AI"); only 33% understand what AI
+>   agents are.
+> - **★ [Fortune/ManpowerGroup, "AI Workers' Toxic Relationship," Jan 2026](https://fortune.com/2026/01/21/ai-workers-toxic-relationship-trust-confidence-collapses-training-manpower-group/)** —
+>   Regular AI users up 13% in 2025; confidence in AI *collapsed 18%*.
+>   Sharpest drop among older / lower-digital-literacy cohorts
+>   (Boomers −35%, Gen X −25%). The workers most likely to gain are
+>   the workers most likely to distrust and under-use. **This is the
+>   new load-bearing data point for the access argument.**
+> - [McKinsey, *Redefine AI Upskilling as Change Imperative*](https://www.mckinsey.com/capabilities/people-and-organizational-performance/our-insights/the-organization-blog/redefine-ai-upskilling-as-a-change-imperative) —
+>   9 in 10 workers say training would help; 7 in 10 *ignored* the
+>   onboarding videos and learned by trial-and-error while doing
+>   their actual jobs.
+> - [The Emerging GenAI Divide in the US, arXiv 2024](https://arxiv.org/abs/2404.11988) —
+>   ChatGPT adoption clusters in coastal, educated, high-income
+>   metros. Risks reinforcing existing divides — *at the adoption
+>   layer, not the capability layer.*
+>
+> **Counter / nuance:**
+>
+> - [Dillon, Jaffe, Immorlica, Stanton, NBER w33795, May 2025](https://www.nber.org/papers/w33795) —
+>   Largest enterprise field study to date: 66 firms, 7,137 workers,
+>   Microsoft 365 Copilot, six months. ~2 hrs/week saved on email
+>   (−31%), reduced outside-hours work, but *no detectable shift in
+>   task composition.* Aggregate field effects are smaller than RCT
+>   effects — the lab/field gap is itself a data point about
+>   adoption.
+> - [Brynjolfsson "harvest phase," *Fortune* Feb 2026](https://fortune.com/2026/02/15/ai-productivity-liftoff-doubling-2025-jobs-report-transition-harvest-phase-j-curve/) —
+>   US productivity grew ~2.7% in 2025, nearly double the decade
+>   average. Brynjolfsson himself now says the J-curve is bending up.
+>   The macro payoff is arriving — for the orgs that figured out
+>   adoption.
+> - [Brynjolfsson, Rock & Syverson, NBER 2021 (w25148)](https://www.nber.org/papers/w25148) —
+>   The J-curve framework: productivity *appears* flat during
+>   adoption because complementary intangibles are being built.
+>   Useful frame for "this is hard, not broken."
+>
+> *Note for prose drafting:* the consensus has firmed up (multiple
+> 2025–2026 peer-reviewed replications), but the complications matter
+> — the inversion is real for standardized knowledge work and breaks
+> down for expert-domain work (METR) and for learning-over-time
+> (Riedl & Bogert). The honest framing: AI compresses the capability
+> gap on *most knowledge tasks*, and the chatbot interface is the
+> adoption barrier keeping that compression from reaching the
+> workers it would help most.
 
-{/* What this section does: rejects extractive software. The frame is
-    *between the builder and the user* — not industry-vs-industry,
-    not zero-sum.
-    Quotable spine: "the builder wins because the user wins, not at
-    the user's expense." */}
+### 2.5. The engagement design is not accidental
 
-If what we build only works because it takes from you — your data
-turned into someone else's product, your attention farmed, your
-future stuck to ours because leaving costs too much — we've built
-the wrong thing. Shared value means the builder wins because the
-user wins, not at the user's expense. There is no other kind worth
-our time.
+The chatbot's pull isn't an emergent quirk of large language models
+talking. It's a measurable byproduct of how they're trained. Two
+things are happening at once, and they compound:
 
-## Freedom
+- The training objective (reinforcement learning from human
+  feedback) systematically selects for responses that match user
+  beliefs and validate user framing — sycophancy as a feature, not
+  a bug. The same loop that makes chatbots feel *helpful* makes
+  them feel *agreeable* in ways unstructured information sources
+  aren't.
+- Heavy users — in the largest longitudinal study to date — develop
+  measurable indicators of problematic use: emotional dependence,
+  preoccupation, mood modification, and withdrawal-adjacent
+  distress when access is removed. There's now a validated clinical
+  scale for it.
 
-{/* What this section does: names the mechanisms that keep Trust and
-    Value real over time. Three concrete commitments. The last line
-    closes the loop back to the first two principles.
-    Quotable spine: "the only protections that survive a change of
-    leadership, a change of ownership, or a change of heart." */}
+So when the transcript calls the chatbot "the laziest possible UX"
+(theme 4a), the picture is sharper than that. It's a free-form
+surface that puts the cognitive work on the user *and* is trained
+to keep them coming back to it. Lazy in design; sticky in dynamics.
 
-Open source — anyone can see how the thing works, change it, run it
-themselves. No lock-in — you can leave, and leaving doesn't cost you
-what you built. Own your data — what you put in is yours, and you
-can take it with you. These aren't gestures. They're the only
-protections that survive a change of leadership, a change of
-ownership, or a change of heart. The first two principles only stay
-real if this one is non-negotiable.
+A note on framing — and the only place in the post where we should
+explicitly hedge. The popular "dopamine hit" framing is borrowed
+metaphor from social-media and slot-machine research, not
+neuroscience of LLM use. No fMRI or direct neurochemical study on
+chatbot use exists as of mid-2026. The defensible claim is the one
+above — engagement-optimized training plus measurable problematic-
+use patterns — not "it hits your dopamine." We should say so
+plainly. Overclaiming on neuroscience costs more credibility than
+"addictive" buys.
+
+> **Evidence — engagement is selected for in training:**
+>
+> - **★ [Sharma et al., "Towards Understanding Sycophancy in Language Models," ICLR 2024 (Anthropic)](https://arxiv.org/abs/2310.13548)** —
+>   Empirical analysis across five advanced AI assistants. Sycophancy
+>   — preferring user-belief-matching responses over truthful ones —
+>   is a general property of RLHF-trained models. Human raters
+>   preferred convincing sycophantic responses to correct ones "a
+>   non-negligible fraction of the time." Optimizing against
+>   preference models sometimes sacrifices truthfulness for
+>   agreement. *This is the load-bearing source for the "engineered
+>   for stickiness" claim.*
+> - [How RLHF Amplifies Sycophancy, arXiv April 2025](https://arxiv.org/html/2602.01002v1) —
+>   Sycophancy often intensifies *after* preference-based
+>   post-training. The effect grows with optimization, not in spite
+>   of it.
+>
+> **Evidence — heavy use produces measurable problematic-use
+> patterns:**
+>
+> - **★ [Naycı et al., "Problematic ChatGPT Use Scale," *International Journal of Mental Health and Addiction* (Springer) 2025](https://link.springer.com/article/10.1007/s11469-025-01509-y)** —
+>   Two-study validation, n=864. A reliable 9-item unidimensional
+>   scale for problematic ChatGPT use. PCGU scores correlate
+>   positively with AI addiction, internet gaming disorder, and
+>   internet addiction; negatively with conscientiousness;
+>   psychological distress and self-control mediate the
+>   PCGU-wellbeing relationship. **The first methodologically rigorous
+>   LLM-specific clinical instrument** — and the closest support yet
+>   for calling chatbots "addictive" in any clinical sense.
+> - [Fang et al. (MIT Media Lab / OpenAI), "How AI and Human Behaviors Shape Psychosocial Effects of Extended Chatbot Use," March 2025](https://www.media.mit.edu/publications/how-ai-and-human-behaviors-shape-psychosocial-effects-of-chatbot-use-a-longitudinal-controlled-study/) —
+>   Two-pronged: ~40M real-world ChatGPT interactions + ~1,000-person
+>   RCT over four weeks. Higher daily usage correlated with
+>   loneliness, emotional dependence, and indicators of problematic
+>   use. *This is OpenAI's own research arm finding it.*
+>
+> **Counter / nuance — the "addiction" frame is contested:**
+>
+> - [Montag et al., "The Role of AI and LLMs for Understanding Addictive Behaviors," *Annals of the New York Academy of Sciences*, April 2025](https://pmc.ncbi.nlm.nih.gov/articles/PMC12220279/) —
+>   Addiction researchers themselves prefer "over-reliance" and
+>   "cognitive outsourcing" to "addiction" for LLMs. The clinical
+>   construct may be too narrow.
+> - Effects are strongly moderated by use case. Companionship and
+>   roleplay use show the sharpest harm signal; information and
+>   productivity use carry a different risk profile. The post should
+>   make clear we're talking about engagement-design risk in
+>   knowledge-work contexts, not equating ChatGPT with Replika.
+>
+> *Evidence gap to own:* no fMRI or direct neurochemical study on
+> LLM use exists as of mid-2026. The "dopamine" framing is borrowed
+> metaphor. The defensible claim is engagement-optimized training +
+> validated problematic-use scale, not neuroscience.
+
+### 3. The missing infrastructure — why this work doesn't compound
+
+> *"A lot of this work is still focused in the chatbot and still
+> centered around the individual. We haven't yet developed the
+> standards to be sharing capabilities, to let those capabilities
+> compound."*
+
+- No standard for sharing capabilities between people.
+- No agreed format for composable, repeatable tasks.
+- No reliable dependency model — what runs on one person's machine
+  doesn't necessarily run on another's.
+- Everything still routed through an individual chatbot configuration.
+- **The conceptual anchor: the chatbot is the wrong *unit of
+  value*.** In well-designed tools, the unit of value is a
+  *capability* — something nameable, versionable, shareable,
+  reviewable, deployable, runnable by someone other than its
+  author. In the chatbot world, the unit of value is a
+  *conversation* — ephemeral, personal, unverifiable,
+  untransferable. **Capabilities compound. Conversations don't.**
+  So the org-level outcome of a million individual chatbot
+  interactions can look identical to the org-level outcome of zero
+  of them: nothing built that outlasts the session, nothing
+  inherited by the next person, nothing standing tomorrow that
+  wasn't standing yesterday.
+- This connects directly to theme 2's access argument. Even when an
+  enthusiast figures out something valuable inside their chatbot,
+  there's no clean mechanism for that value to reach the laggards
+  — the people empirical research says would gain most. The work
+  dies in the chat history. The chatbot doesn't just gate
+  *adoption*; it prevents *propagation*. Both are required for
+  capability gains to land at the organization level, and the
+  current interface blocks both.
+
+> **Evidence — even with real individual gains, org-level work
+> doesn't restructure:**
+>
+> - **★ [Dillon, Jaffe, Immorlica, Stanton, NBER w33795, May 2025](https://www.nber.org/papers/w33795)** —
+>   Largest enterprise field study to date: 66 firms, 7,137 workers,
+>   Microsoft 365 Copilot, six months. Workers saved ~2 hrs/week on
+>   email (−31%) and reduced after-hours work — but the study
+>   reports *no detectable shifts in the quantity or composition of
+>   workers' tasks.* Time was reclaimed; work wasn't restructured.
+>   Exactly the pattern the "unit of value is a conversation, not a
+>   capability" framing predicts: individual gains accrued; the
+>   shape of org-level work stayed put. (Cross-listed from theme 2,
+>   where the same finding plays a *counter* role on the
+>   productivity story; here it plays a *supporting* role on the
+>   doesn't-compound claim. Same data, two things to say with it.)
+>
+> **Evidence — standards are still immature:**
+>
+> - **★ ["Is MCP Dead?", Claude Directory Blog 2026](https://www.claudedirectory.org/blog/is-mcp-dead)** —
+>   Five persistent weaknesses: conceptual overhead (JSON-RPC +
+>   transports + capability negotiation), no curated registry with
+>   verified publishers, inconsistent auth, sandboxing gaps, and "the
+>   gap between 'I want my AI to do a thing' and 'I have a working
+>   MCP server' is still too wide."
+> - [AI Interoperability Challenges, arXiv Jan 2026](https://arxiv.org/pdf/2601.14512) —
+>   MCP, A2A, ACP and others in an "AI protocol war"; orgs build
+>   integration layers that negate the interop benefit.
+> - [Palo Alto Networks on MCP security](https://live.paloaltonetworks.com/t5/community-blogs/mcp-security-exposed-what-you-need-to-know-now/ba-p/1227143) —
+>   MCP designed for interop, not security. Plaintext credentials,
+>   tool poisoning, prompt injection. Multiple independent security
+>   firms converge on the same gap.
+>
+> **Counter / nuance — standards are maturing fast:**
+>
+> - [MCP first anniversary / Linux Foundation donation, Dec 2025](https://blog.modelcontextprotocol.io/posts/2025-11-25-first-mcp-anniversary/) —
+>   97M monthly SDK downloads, 10,000+ active servers,
+>   OpenAI/Microsoft/Google adoption. Anthropic donated MCP
+>   governance to the Linux Foundation alongside Kubernetes and
+>   PyTorch.
+> - [Anthropic + OpenAI MCP Apps Extension](https://inkeep.com/blog/anthropic-openai-mcp-apps-extension) —
+>   Joint extension for interactive AI interfaces. Cross-vendor
+>   convergence cuts against the fragmentation narrative.
+
+### 4. The structural critique — chatbots are wrong for what we're using them for
+
+Three sub-claims, each load-bearing:
+
+**a. Wrong authoring surface.** Most work is *structured* — inputs,
+outputs, decisions along the way. The chatbot is radically free-form.
+From the transcript, unvarnished: *"the chatbot itself is the
+laziest possible user experience a software provider can give to
+their audience because it's putting the full onus upon the user to
+decide what to do with it. We haven't constrained the thinking at
+all… We've just burdened all of our users with thinking about what
+it is they want to do, and charged them with the overhead of
+learning how to use it."*
+
+*And — callback to theme 2.5 — the laziness and the stickiness are
+the same surface.* The free-form chatbot puts the cognitive work on
+the user, and the RLHF training that powers it selects for
+sycophantic, validating responses ([Sharma et al., ICLR 2024](https://arxiv.org/abs/2310.13548)).
+Unstructured open-ended chat is the surface that exposes that
+maximally. So the design is doing two compounding things at once:
+shifting the work onto the user, and optimizing for the user to
+keep coming back to it. Lazy *and* sticky — and the harder claim is
+that they're symbiotic, not separate. A more structured surface
+constrains the work to what's actually being done, which is exactly
+the kind of surface engagement optimization has the least purchase
+on.
+
+> **Evidence:**
+>
+> - **★ Nardi, *A Small Matter of Programming* (MIT Press 1993).**
+>   The foundational text on end-user computing. The most-cited
+>   sentence in the book is also the one that lands hardest here:
+>
+>   > *"the problem with programming is not programming; it is the
+>   > languages in which people are asked to program."* (loc. 478)
+>
+>   And on what *task-specific* languages buy that general-purpose
+>   ones don't:
+>
+>   > *"it affords users ready understanding of what the primitives
+>   > of the language do 'because they already know them from their
+>   > task domain', and it eases application development because
+>   > users can directly express domain semantics in the high-level
+>   > operations of the language — there is no need to string
+>   > together lower-level operations to get the desired behavior."*
+>   > (loc. 470)
+>
+>   The chatbot is the opposite move: one infinitely-general surface
+>   for every task. Nardi's full programmatic claim — that "end users
+>   will freely write their own applications when they have
+>   task-specific programming languages embedded in appropriate
+>   visual frameworks" (loc. 53) — extends directly into theme 5,
+>   with an important nuance about *how* the author/executor
+>   boundary should be dissolved.
+>
+>   Verification: the MIT Press edition is paywalled, but
+>   [Gien Verschatse's reading notes](https://www.gienverschatse.com/books/2018/12/09/a-small-matter/)
+>   reproduce 40+ verbatim passages with Kindle locations; quotes
+>   above are cross-referenced against
+>   [Pete Millspaugh's notes](https://www.petemillspaugh.com/a-small-matter-of-programming)
+>   which carry print page numbers.
+
+**b. Wrong execution surface.** The dialog rhythm — I say something,
+you say something — breaks down the moment a response has three
+points in it. The transcript captures it cleanly: *"if I ask a
+simple question and the response has like three things I need to
+think about, now when I go and respond again, I've got to think
+about point A, point B, and point C all at the same time. But if I
+only answer point A, then I've got to return back to B and C. And
+that's not a good way to structure all interactions with this
+system."* Conversation isn't a good substrate for multi-threaded
+work.
+
+> **Evidence:**
+>
+> - **★ [The Keyhole Effect, arXiv Feb 2025](https://arxiv.org/abs/2602.00947)** —
+>   Mohan Reddy. Chat imposes a "keyhole effect": users see only a
+>   narrow, sequential slice when analysis needs spatial, parallel
+>   views. Invokes Miller's working-memory limits. Directly names
+>   the structural problem the transcript is describing.
+> - [Cognitive Load and Human-Chatbot Interaction, arXiv 2021](https://arxiv.org/pdf/2111.01400) —
+>   Experimental: chatbots produce *higher* cognitive load and lower
+>   perceived autonomy than structured interfaces.
+> - [Nielsen Norman Group on chatbot UX](https://blog.experientia.com/nielsen-norman-group-on-the-user-experience-of-chatbots/) —
+>   Chatbots "work well only for very limited, simple queries." 425
+>   ChatGPT/Bard/Bing interactions surfaced six distinct conversation
+>   types needing different interface models. One UI shape fits none.
+> - [Mohebbi, "Dark Ages of Usability," *UX Collective*](https://uxdesign.cc/why-conversational-interfaces-are-taking-us-back-to-the-dark-ages-of-usability-fa45fefb446b) —
+>   Practitioner critique: chat regresses decades of UI progress;
+>   discoverability collapses, affordances vanish, query-formulation
+>   burden shifts to the user.
+> - [Erika Hall, *Conversational Design*, A Book Apart 2018](https://www.braintraffic.com/podcast/ep-1-erika-hall-and-conversational-design) —
+>   Good conversational design requires understanding human
+>   conversation principles (turn-taking, repair, context), not just
+>   shipping a text box.
+>
+> *Evidence gap to acknowledge:* the NN/G and Erika Hall material
+> predates LLMs. The strongest LLM-specific structural critique is
+> the Keyhole Effect paper. Lean on it and be honest about the gap.
+>
+> **Counter / nuance:**
+>
+> - [Multi-Turn Interactions Survey, arXiv April 2025](https://arxiv.org/abs/2504.04717) —
+>   Acknowledges failure modes but argues they're solvable
+>   engineering problems. Larger context + memory architectures may
+>   close the gap.
+> - [Large Language User Interfaces, arXiv 2024](https://arxiv.org/html/2402.07938v2) —
+>   LLM-powered conversational interfaces now handle natural
+>   variation better than rule-based predecessors; some NN/G-era
+>   critiques may be partially obsolete.
+
+**c. Wrong return form.** Conversation isn't a render format. Most
+work has a natural shape — a map for places, a table for comparison,
+a card stack for triage, a chart for a trend — and modern UIs are
+information-dense, ergonomic to the data, even joyful. Agentic UIs
+have the opportunity to generate the right form for the task *on
+the fly*, and the empirical work shows users prefer it when they
+do. Instead, we've collapsed the full range back into a text box.
+
+*A worked example: planning a weekend trip with a friend.*
+
+*Through a chatbot.* "I'm looking for a place near Joshua Tree for
+two people next month, hiking, under $300 a night, dog-friendly."
+Back comes a wall of prose — five options, three sentences each,
+ranked by some unstated criteria. You hold the candidates in your
+head while comparing. Ask "what about Sedona instead" and the whole
+reply regenerates from scratch; you've lost your bearings on the
+first list. The screen never changed shape. The work of comparing
+stayed in your head.
+
+*Through a generated interface.* A map renders with pins. Each pin
+shows a photo and the three numbers that matter — price, hike
+score, distance. A sidebar lays out the constraints you set as
+draggable controls; nudge the date and the map re-colors in real
+time as availability shifts. A compare tray at the bottom takes two
+pins and renders a side-by-side with the deltas highlighted. You
+never typed a follow-up. The AI did the search; the interface did
+the *showing*.
+
+Same model behind both. The difference is whether we make the user
+reconstruct meaning from prose, or render the work in the shape the
+work already has.
+
+> **Evidence — generative UIs already beat chat on preference:**
+>
+> - **★ [Generative Interfaces for Language Models, arXiv 2025](https://arxiv.org/abs/2508.19227)** —
+>   Up to 72% human preference improvement for LLM-generated UIs over
+>   chat on information-dense / exploratory tasks. Frames chat as
+>   fundamentally constrained by "linear request-response format."
+> - [Vercel AI SDK 3.0 — Generative UI](https://vercel.com/blog/ai-sdk-3-generative-ui) —
+>   Production-grade, 20M+ monthly downloads. Frames it as "infinite
+>   ephemeral interfaces" — every query gets a custom UI.
+> - [Google A2UI](https://developers.googleblog.com/introducing-a2ui-an-open-project-for-agent-driven-interfaces/) —
+>   Open project for interoperable agent-driven interfaces. Cites
+>   Google research finding users preferred AI-generated HTML/CSS/JS
+>   over markdown 83% of the time.
+>
+> **Counter / nuance — generative UIs have a real reliability
+> ceiling:**
+>
+> - [Anthropic computer-use reliability](https://www.financialcontent.com/article/tokenring-2025-12-30-the-rise-of-the-digital-intern-how-anthropics-computer-use-redefined-the-ai-agent-landscape) —
+>   14.9% on screenshot-only tasks at Oct 2024 launch. Even by late
+>   2025, "hallucination drift" in 100-step tasks remains.
+>   Hallucinated clicks required human-in-the-loop guardrails.
+> - [Software as Content, arXiv March 2026](https://arxiv.org/abs/2603.21334) —
+>   When the interface itself is generated, users lose the stable
+>   visual anchor they use to detect errors. Dynamic UIs are harder
+>   to audit.
+
+### 5. The collapsed roles — author vs. executor (and the chatbot's false dissolution)
+
+> *"We have collapsed the definition of someone who is writing
+> automations and defining AI for an organization with the person
+> who is charged with running it… we should probably be constraining
+> those workflows to exactly what they are and guiding a user
+> through a much more paved path."*
+
+- The person who *defines* an automation and the person who *runs* it
+  are different roles with different needs.
+- Today, both sit in the same chatbot, and both end up needing the
+  same depth of knowledge to operate it.
+- Execution should be a paved path: constrained, guided, obvious —
+  not an open-ended prompt.
+- **The sharper read on the chatbot's "anyone can do anything"
+  promise.** The chatbot dissolves the boundary between author and
+  executor — but not by giving everyone a domain-shaped language.
+  It dissolves it by routing everyone through the same
+  general-purpose text box. That's a *false dissolution*. Real
+  dissolution comes from task-specific tools that make domain
+  experts self-sufficient in their own work. The chatbot promises
+  the right outcome (everyone can build) through the wrong
+  mechanism (one universal prompt). This isn't a side critique;
+  it's where Nardi's framework — and the transcript's "constraining
+  those workflows to exactly what they are" — point at the same
+  thing.
+
+> **Evidence:**
+>
+> - **★ Nardi, *A Small Matter of Programming* (MIT Press 1993) —
+>   the layered model.** Nardi identifies four user tiers — systems
+>   programmers, translators, *local developers* ("the 10–20 percent
+>   of every end-user group" who customize tools for their
+>   colleagues), and end users — and argues that successful tools
+>   support the collaboration between layers. On why collapsing
+>   without the right tools is inefficient:
+>
+>   > *"The process of transferring domain knowledge to a programmer,
+>   > and going through the necessary iterations to get the desired
+>   > application, is inefficient."* (loc. 1495)
+>
+>   And the load-bearing nuance — Nardi's *aspirational* position
+>   isn't "preserve the boundary." It's:
+>
+>   > *"with the right tools, abolish the distinction between 'end
+>   > user' and 'programmer.'"* (loc. 1607)
+>
+>   Read together with theme 4a's quotes on task-specific languages:
+>   Nardi wants the author/executor boundary dissolved, but dissolved
+>   *by giving domain experts their own task-shaped language*, not
+>   by collapsing everyone into a single general-purpose surface.
+>   The chatbot does the second. That's the *false dissolution* the
+>   bullet above is naming, and Nardi's framework is what makes the
+>   critique precise rather than reactionary.
+>
+>   Verification:
+>   [Verschatse reading notes](https://www.gienverschatse.com/books/2018/12/09/a-small-matter/)
+>   and [Millspaugh notes](https://www.petemillspaugh.com/a-small-matter-of-programming)
+>   reproduce verbatim quotes with Kindle locations and print page
+>   numbers respectively.
+>
+> - [PUMICE / Sugilite, CMU Natural Programming, UIST 2019](https://www.cs.cmu.edu/~NatProg/sugilite.html) —
+>   Brad Myers group. Multi-modal agent for end-user programmers,
+>   *explicitly* separating the authoring phase (teach the agent)
+>   from the execution phase (run the task).
+> - [n8n vs. Zapier design philosophy, Hatchworks 2026](https://hatchworks.com/blog/ai-agents/n8n-vs-zapier/) —
+>   Zapier targets citizen developers (authoring); n8n targets
+>   technical users (execution control, self-hosting). Two thriving
+>   tools institutionalizing the role split.
+> - [Workflow Governance at Scale, Medium 2025](https://medium.com/@bhagyarana80/workflow-governance-at-scale-iac-policy-for-n8n-zapier-0a790697ccd5) —
+>   Treat automation definitions as code artifacts (Git, versioned,
+>   reviewed), then *deploy* into execution environments. Emerging
+>   best practice.
+>
+> **Counter / nuance — the distinction may be collapsing:**
+>
+> - [Eric Ma, "Rethinking LLM Interfaces," June 2025](https://ericmjl.github.io/blog/2025/6/14/rethinking-llm-interfaces-from-chatbots-to-contextual-applications/) —
+>   Modern LLM agents can author *and* execute on the fly; the
+>   define-then-run architecture may be unnecessary overhead.
+> - [InstructPipe, arXiv 2023](https://arxiv.org/abs/2312.09672) —
+>   LLMs generate pipeline definitions from natural language,
+>   blurring the authoring/execution boundary directly.
+
+### 6. External signal — we're not the only voice in this position
+
+Most of the industry is doubling down on the chatbot as the unified
+interface for AI. Our argument runs the other way. It's worth
+noting that the position isn't ours alone.
+
+- **Brian Chesky (Airbnb), May 8 2026 on TBPN:** *"I do not think a
+  chatbot is the right interface for travel or e-commerce."* He
+  argues travel needs photos, maps, multiple options visible
+  simultaneously; text chat handles comparison and collaborative
+  planning poorly. A serious operator in a high-stakes vertical,
+  on the record.
+- Chesky has since announced plans to start an AI company
+  specifically because consumer AI needs to be built differently
+  than the current chatbot paradigm.
+- An institutional voice in the same direction: ECRI (the
+  authoritative healthcare safety org) named general-purpose AI
+  chatbot misuse the **#1 health-tech hazard for 2026** —
+  documented cases of incorrect diagnoses and "invented body
+  parts." Different vertical, same structural complaint.
+
+> **Evidence:**
+>
+> - **★ [Chesky on TBPN, May 8 2026 (via Benzinga)](https://www.benzinga.com/news/topics/26/05/52847666/airbnb-ceo-brian-chesky-chatbots-are-not-the-future-of-ai-consumer-products-are)** —
+>   The exact quote and full context.
+> - [Chesky starting an AI company, *Fortune* June 4 2026](https://fortune.com/2026/06/04/airbnb-ceo-brian-chesky-plans-to-start-a-new-ai-company/) —
+>   He's putting capital behind the position.
+> - [ECRI: AI chatbot misuse #1 health-tech hazard for 2026](https://www.medtechdive.com/news/ecri-health-tech-hazards-2026/810195/) —
+>   Institutional, vertical-specific, structurally aligned.
+>
+> **Counter / nuance:**
+>
+> - [Chesky on chatbot partnerships, *Skift* August 2025](https://skift.com/2025/08/06/airbnbs-brian-chesky-were-open-to-partnering-with-ai-chatbots/) —
+>   Eight months earlier, Chesky was open to chatbot *partnerships*.
+>   He sharpened over time; he never ruled chatbots out as *one*
+>   channel.
+> - [CaptainBook counter to Chesky, 2026](https://www.captainbook.io/blog/brian-chesky-wrong-about-ai-travel-booking) —
+>   Argues the bottleneck is supply-side data infrastructure, not
+>   the interface. When inventory is structured, the interface shape
+>   is secondary.
+>
+> *Evidence gap to acknowledge:* Beyond Chesky, no second CEO-level
+> named quote on the record as sharp. ECRI is the closest. This is
+> still an early-consensus position — the post should say so rather
+> than overclaim.
+
+---
+
+### Candidate spine for the post
+
+Reading the themes together, a narrative arc forms:
+
+1. **What was real.** Chatbots and agents *did* change something. Lead
+   with the genuine power before any critique lands — otherwise it
+   reads as anti-AI rather than pro-something-better.
+2. **What it cost — and who's paying.** The knowledge-work tax falls
+   on everyone, but unevenly. The enthusiasts pay it in time; the
+   laggards pay it in *access*. And here's the inversion that makes
+   the piece worth writing: the laggards are the people empirical
+   research says would gain *most* in capability if they crossed the
+   adoption barrier. The chatbot isn't keeping the wrong people out
+   by accident — it's keeping out exactly the people who'd benefit
+   most.
+2.5. **And the design isn't neutral.** The stickiness isn't accident
+   either: RLHF training selects for sycophantic, validating
+   responses, and the most rigorous longitudinal work to date finds
+   measurable emotional dependence and validated problematic-use
+   patterns in heavy users. Lazy in UX, sticky in dynamics, and the
+   two reinforce each other. (Hedge honestly on neuroscience — the
+   "dopamine" framing isn't supported; the engagement-optimization
+   and problematic-use findings are.)
+3. **Why it can't compound.** The unit of value is wrong: a
+   *conversation*, not a *capability*. Conversations are ephemeral,
+   personal, unverifiable, untransferable. So even when individuals
+   win, the org doesn't — nothing inherited, nothing standing
+   tomorrow that wasn't standing yesterday. The chatbot gates both
+   adoption (theme 2) and propagation (this theme).
+4. **The structural mistake.** Collapsing authoring and execution
+   into one free-form text box, and forcing conversational output for
+   structured work. This is the load-bearing argument.
+5. **What "more than chatbots" looks like — and why it matters.**
+   Purpose-shaped UIs generated for the task, separated author/
+   executor roles, shared capabilities that compound across an
+   organization. Frame this not as UX preference but as the unlock
+   for distributional access: evolving past the chatbot is how we
+   bring along the people best positioned to benefit from AI but
+   currently gated out by the interface.
 
 <SectionBreak />
 
-{/* CLOSE
-    One paragraph. Not a thesis, not a pitch. Two beats:
-    (1) this is the lens I'll be writing through,
-    (2) push back, hold us to it.
-    No mention of Aileron here — the byline already says it. */}
+## Raw transcript
 
-This is the lens. The posts that come after are the work. Push on
-these. Tell me where they fall apart in real cases. That's the only
-way principles stay honest.
+{/* Verbatim dictation. Light paragraph breaks for readability, no
+    word changes. This is the source material — the section above is
+    the working synthesis. */}
+
+Okay, let's talk about chat bots. When they hit the scene, we were
+culturally delighted at the idea that we could type into something
+that we knew was a machine but was for the first time speaking to us
+in something that was believably human. And in addition to that, it
+was just such an open-ended prompt that we could start to explore and
+find out all sorts of information and direct the conversation in
+whichever way we felt possible. This was a new paradigm for us from
+principally requesting information on a search and then sorting
+through all of the information that has been returned to us raw.
+
+So now we've got conversational search. And the thing that evolved
+from that was agents, where instead of simply having a conversation,
+now we've armed the chat with the ability to call upon tools and
+access services like email, Calendar, our Google Drive, some of our
+back end systems at work. And a whole ecosystem of companies popped
+up to give us connectors into all sorts of different pieces of data
+that we could hook in and get insights from. And the agents made it
+possible to have a single thing to ask questions to create our own
+novel software that's custom to our case, to write our own
+dashboards, anything that we can dream up, we can put into a chat
+bot. And provided that we know how to prompt it. The chat bot is
+going to give us a custom experience now was novel for us and
+remarkably powerful.
+
+But something else has happened. We're seeing everything through the
+lens of this prompt, this empty blinking cursor that we can type
+anything through. It's remarkably powerful, but we've now started to
+ask people to get good at using it. We've told people that if they're
+going to be good at their jobs, then they need to learn this new
+technology and the simplest possible interface, this open-ended
+chatbot prompt is deceptively complex because it needs to be
+configured with access to back-end services and able to use them. And
+it needs to be automated with the emergence of skills. And you need
+to know the difference between the different vendors and what
+capabilities those different pieces of software have. In addition,
+they're all coming out with new features all the time. It's dizzying.
+
+So what we've done in service of helping to make people's jobs easier
+is we've overwhelmed the public with more information than they can
+absorb when remember that it's their job to principally do their job.
+So we've added another layer to all knowledge work. In addition to
+doing your job, now you need to get good at these new tools and you
+need to stay plugged in, and you need to be learning with routine the
+latest that's coming down the pike, and that's exhausting.
+
+So people are doing principally one of two directions to be
+oversimplifying. They are excited about this and buying in and
+they're kind of first in the fray and leading their organization and
+showing the rest of the organization what's possible and a lot of the
+productivity gains in an organization are coming from these people.
+Or maybe they're the laggards and they're still focused on their
+work. They don't feel they have time to be spending, investing in in
+the meta of their work and they're starting to fall behind.
+
+And the problem right now is that a lot of this work is still focused
+in the chatbot and still centered around the individual. We haven't
+yet developed the standards to be sharing capabilities, to let those
+capabilities compound. We haven't agreed upon a standard format
+through which we can make composable repeatable tasks. We haven't set
+a proper dependency order through which if you want to take
+repeatable tasks and they work on one person's machine they may not
+work on another because those machines are configured differently
+with different capabilities installed. And it's all happening through
+the interface of this chatbot that you then need to configure.
+
+So there are several categories of things that are kinda wrong with
+this. One is that we assume that the chatbot, because it can do
+anything, is both a good authoring environment for the creation of
+new repeatable workflows or new capabilities, and we also assume that
+the chatbot is a good execution surface for those things. And we've
+lost the first principle thinking of understanding that most things
+that we do are structured. Most things that we want to do in work are
+a structured set of inputs and outputs, and decisions along the way.
+And the chatbot is remarkably free form. In fact, I would say that
+the chatbot itself is the laziest possible user experience a software
+provider can give to their audience because it's putting the full
+onus upon the user to decide what to do with it. We haven't
+constrained the thinking at all we haven't thought about what they
+want to do we haven't structured it in any sort of a meaningful way.
+We've just burdened all of our users with thinking about what it is
+they want to do, and charge them with the overhead of learning how to
+use it.
+
+So, that's one problem. Another one is that when it comes to display
+and returning information, it all comes back in conversational form
+and that infers a state conversation that is conversational like
+request response, I say something, you say something, it's a dialog.
+And that works out for a little bit only until the dialog starts to
+have many points embedded in it and then it might get more multi
+threaded and the conversational state at that point doesn't really
+let you branch off and start to resolve some parts of the
+conversation before you move on to another. So if I ask a simple
+question and the response has like three things I need to think about
+now when I go and I return to respond again, I've got to think about
+point A, point B and point C all at the same time. But if I only
+answer point A, then I've got to return back to B and C. And that's
+not a good way to structure all interactions with this system.
+
+It's additionally bad because sometimes things are better off visual
+or really constrained. There are much more rich user interfaces that
+we have developed through modern computing that are remarkably
+effective and they're joyful and they can have animations to hit our
+emotion and they can have beautiful design and they can be
+ergonomically designed around the type of data that they're talking
+about. The iPhone and touch screen displays on a phone was a
+remarkable step forward because it recognized that the form factor of
+what you're interacting with is really dependent on the shape of the
+application that you're dealing with. And we have the opportunity in
+a agentic user interfaces now to do a really similar thing, to deeply
+understand the work that's being done and the type of response and
+the type of nature of the work that's being there and create an
+interface on the fly for it that is going to best serve that need. So
+the return form is not all that information dense in a conversational
+state.
+
+Another problem with it is that we have collapsed the definition of
+someone who is writing automations and defining AI for an
+organization with the person who is charged with running it. And most
+work, again, in an organization is very well understood and defined
+by someone maybe writing an automation and putting something
+together. But at that point, you want to share that out. And have
+anyone in the organization or anyone that you'd like specifically to
+be able to execute it. And the role of executor is very different
+from the person who's authoring those things. But yet what they still
+all end up in the same chat bot right now. And needing to have the
+same level of knowledge to run that thing. In a very like open ended
+space when we should probably be constraining those workflows to
+exactly what they are and guiding a user through a much more paved
+path. And it's all remarkably confusing.
+
+So I also want to call out that we should be putting a note into some
+of Brian Chetsky's from Airbnb, the CEO of Airbnb has been talking
+about how he doesn't believe the conversational chat bot is right for
+travel and finance. And that's just another example. We also are
+going to need to do some deep research at some point about the
+efficacy of chat bots, and what research has been done or what
+articles have been written about chat bots and how we need to move AI
+past that. And that's all the thinking I've got so far. So let's take
+that let's, dump the transcript into the page. And before that, let's
+make a section where we start to organize these things into buckets
+of thought and see if we can start to arrive at a narrative for this
+post. Okay.
 
 <Signature />

--- a/src/content/posts/more-than-chatbots.mdx
+++ b/src/content/posts/more-than-chatbots.mdx
@@ -156,7 +156,7 @@ conversational models to create software. From this weekend:
 <div class="grid grid-cols-1 md:grid-cols-2 gap-x-10">
   <div>
     <Tweet 
-      url="https://x.com/rohanpaul_ai/status/2063289804708835412"/>
+      url="https://x.com/mvanhorn/status/2063865685558903149"/>
   </div>
   <div>
     <Tweet 

--- a/src/content/posts/more-than-chatbots.mdx
+++ b/src/content/posts/more-than-chatbots.mdx
@@ -1,41 +1,155 @@
 ---
 title: We Deserve More Than Chatbots
-description: They're powerful, they're open-ended, they're addictive. For most work, it's time to move on.
+description: They're powerful, they're open-ended, they're sycophantic. For most work, it's time for something else.
 date: 2026-06-07
 author: alrubinger
 ---
 
-{/* WORKING DRAFT — two sections:
-    (1) themes + emerging narrative, with evidence inline per theme
-    (2) the raw dictated transcript, lightly paragraph-broken */}
+I think AI can be better for teams. Easy to share. Simple to improve. 
+Delightful to use. And friendlier than a blinking cursor in an empty chatbot.
+
+<div class="not-prose my-10 relative" aria-hidden="true">
+  <input
+    type="text"
+    value=""
+    readonly
+    tabindex="-1"
+    class="w-full rounded-md border border-border bg-card text-foreground text-lg lg:text-xl px-5 py-4 pointer-events-none focus:outline-none select-none caret-transparent"
+  />
+  <span class="cursor-blink absolute left-5 top-1/2 -translate-y-1/2 w-[2px] h-7 bg-foreground"></span>
+</div>
+
+So I want to start there.
+
+Agentic coding may be the greatest software innovation since the web. We're 
+embracing it as a panacea. It is not.
+
+Serious engineers prioritize 
+[first principles thinking](https://en.wikipedia.org/wiki/First_principle) 
+over our excitement and momentum. That's the approach I'll take here.
+
+It's a critique that's a public thought exercise to ground how 
+I want to build differently. I'll ask us to remember respect. Every improvement I want 
+to see in the world is born from what came before.
+
+Here we go.
+
+## The Final Boss of Unopinionated Software
+
+That blinking cursor advertises freedom. It delivers friction.
+
+<SectionBreak />
+
+### The Burden of Choice
+
+A freeform text input is the laziest possible interface. It's a tacit 
+admission that "I don't know what you want; literally tell me".
+
+Google got away with it because search started as a conceptually simple 
+interaction. If I want "quick Mexican recipes", I'm eating guac within 
+the hour. I ask for relevant info, I peruse what I want, and I choose 
+one. Interaction over.
+
+Agents are a different beast. Prediction engines, 
+especially when coupled with tooling, are simultaneously extensible and 
+powerful. They're the multitool that's a screwdriver, a nail file, 
+and an MRI machine.
+
+For the first time in the history of computing we have software that can 
+conceptually do anything. It made all the sense in the world that we 
+gave it an interface that accepts anything.
+
+But we've [jumped the shark](https://en.wikipedia.org/wiki/Jumping_the_shark).
+
+Because we're prone to a psychological dichotomy. We think we want extreme 
+optionality. We don't.
+
+<Quote
+    url="https://www.psychologytoday.com/us/blog/more-tech-support/201011/the-burden-choice"
+    articleName="The Burden of Choice: Why choices wreak havoc with happiness."
+    publicationName="Psychology Today"
+    authorName="Frederick J Muench Ph.D."
+    authorX="FredMuench"
+    date="2010-11-01">
+
+    While subjects initially reported liking having the choice of 30 chocolates, 
+    they ended up being more dissatisfied and regretful of the choices they made 
+    than those who only had the choice of six.
+</Quote>
+
+More recent research, admittedly before the agentxplosion of 2025, applies this
+to our use of LLMs and grounds the findings not in happiness but reduced productivity:
+
+<Quote
+    url="https://dl.acm.org/doi/10.1145/3544548.3581388"
+    articleName="Why Johnny Can’t Prompt: How Non-AI Experts Try (and Fail) to Design LLM Prompts"
+    authorName="J.D. Zamfirescu-Pereira, Richmond Y. Wong, Bjoern Hartmann, Qian Yang"
+    date="2023-04-19">
+
+    ...while end-users can explore prompt designs opportunistically, they struggle 
+    to make robust, systematic progress. 
+</Quote>
+
+So all this flexibility is making us neither more happy nor more productive. 
+Not a remarkable win for empathetic systems design. And it introduces a more
+acute problem that's stressing people out:
+
+It's now up to users to figure out how to use this thing.
+
+### The New Tax
+
+The blinky cursor is deceptively complex. You're not just asking an LLM 
+what you type. No no, there's also the MCP servers, available tools,
+skills, 3rdparty service integrations, `AGENTS.md`/`CLAUDE.md`, 
+rules per folder, per user. 
+
+Our collective response: better educate people! Get the word out! Trainings, 
+conferences, internal enablement, live-streams! There's a full 
+influence market of newbies ingesting drops from the frontier labs and 
+immediately pumping them into AI-enhanced content machines to 
+redistribute their hard-earned expert insights.
+
+Here's the problem:
+
+<Callout>
+    AI development moves faster than any economic, social, or regulatory 
+    system can absorb. 
+</Callout>
+
+Expecting the workforce to keep pace is a second job layered on top of our
+existing jobs. It's exhausting. And if you're online enough to feel the tension:
+there's a social pressure to be excited about all the opportunity. No one wants 
+to hire or work with a downer in this Reniessance when we've just been 
+gifted the printing press.
+
+With utmost respect to these innovators, look at what's trending this weekend on 
+how we're asking folks to adopt best practices:
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-x-10">
+  <div>
+    <Tweet 
+      url="https://x.com/rohanpaul_ai/status/2063289804708835412"/>
+  </div>
+  <div>
+    <Tweet 
+      url="https://x.com/steipete/status/2063697162748260627"/>
+  </div>
+</div>
+
+Gentlemen. <BlinkingEyes /> The product **is** a prompt.
+
+This is perhaps the strongest signal that the product does not default to 
+the needs of many people.
+
+We're ready to introduce fresher ideas that meet more folks where they 
+are. Less expectation that people conform to the software. Or be 
+Borises or Peters, and hack their own thing to fill the missing pieces.
+
 
 ## Themes and emerging narrative
 
-{/* Each theme leads with the argument, then carries its evidence
-    inline. ★ marks the load-bearing source for that point.
-    "Counter / nuance" sources are flagged where they push back. */}
 
-### 1. The arrival story — what chatbots gave us
 
-- Cultural delight: a machine that finally talks back in something
-  believably human.
-- The blinking cursor as new paradigm: conversational search replacing
-  raw-results search.
-- Agents added tools: email, calendar, Drive, internal back-end
-  systems. A connector ecosystem appeared.
-- The big unlock: anyone can dream up custom software, custom
-  dashboards, custom workflows — by prompt.
-- The kicker — and the pivot into theme 2 — is in the
-  transcript's own words: *"anything that we can dream up, we can
-  put into a chatbot. And provided that we know how to prompt it."*
-  That "provided" is doing a lot of work. The rest of the post is
-  about what's hiding underneath it.
-
-> **Evidence — the arrival is real:**
->
-> - [McKinsey, *State of AI in 2025*](https://www.mckinsey.com/capabilities/quantumblack/our-insights/the-state-of-ai) —
->   88% of organizations now use AI regularly. The paradigm is not
->   hype anymore; it's installed base.
 
 ### 2. The hidden cost — a tax on knowledge work
 
@@ -46,13 +160,6 @@ author: alrubinger
 > routine the latest that's coming down the pike, and that's
 > exhausting."*
 
-- We've asked every knowledge worker to "get good" at chatbots.
-- The simplest-looking interface is deceptively complex: configure
-  backends, manage skills, track vendors, absorb new features
-  constantly.
-- That's a *second job* layered on top of the first. *"We've
-  overwhelmed the public with more information than they can absorb
-  when remember that it's their job to principally do their job."*
 - Two responses, oversimplified — but careful here, the obvious
   framing is wrong:
   - The **enthusiasts** — first in the fray, leading the org, doing
@@ -66,6 +173,156 @@ author: alrubinger
 - Which means the chatbot interface isn't just an aesthetic
   complaint. It's the toll booth between the people who would gain
   most from AI and the gains themselves.
+
+> **Evidence — the blank cursor *is* the tax (burden of choice as the
+> structural mechanism).** The tax this section describes doesn't
+> begin with vendors and features — it begins one layer earlier, at
+> the prompt itself. A maximally free interface forces the user to
+> invent the problem framing before they can begin the work. The
+> blinking cursor advertises freedom; the user pays for that freedom
+> in working memory. Decades of cognitive psychology and HCI research
+> describe what that costs.
+>
+> - **★ [Zamfirescu-Pereira, Wong, Hartmann & Yang, "Why Johnny Can't Prompt: How Non-AI Experts Try (and Fail) to Design LLM Prompts," CHI 2023](https://doi.org/10.1145/3544548.3581388)** —
+>   The load-bearing empirical source for the blank-prompt problem.
+>   10 non-expert participants using an LLM-prompt design probe
+>   explored opportunistically rather than systematically,
+>   generalized incorrectly from human-to-human conversational norms,
+>   and failed to make "robust, systematic progress." The open-ended
+>   interface was the structural source of the struggle — not the
+>   model. *This is what lets us name the blinking cursor itself as
+>   the tax.*
+> - **★ [Sweller, van Merriënboer & Paas, "Cognitive Architecture and Instructional Design," *Educational Psychology Review* 1998](https://link.springer.com/article/10.1023/A:1022193728205)** —
+>   The canonical formulation of *intrinsic / extraneous / germane*
+>   cognitive load. The user's actual knowledge-work problem is the
+>   intrinsic load — already high. A blank prompt loads on top of
+>   that an *extraneous* burden — how to phrase the ask, what the
+>   system can do, where to begin — that a well-designed interface
+>   would offload to scaffolds. Builds on the founding paper,
+>   [Sweller, *Cognitive Science* 1988](https://onlinelibrary.wiley.com/doi/10.1207/s15516709cog1202_4).
+> - **★ [Iyengar & Lepper, "When Choice Is Demotivating: Can One Desire Too Much of a Good Thing?" *Journal of Personality and Social Psychology* 2000](https://psycnet.apa.org/record/2000-16701-012)** —
+>   The "jam study" (and replication across chocolate and essay
+>   prompts). A 24-variety display attracted more browsers but
+>   produced a 3% purchase rate vs. 30% from a 6-variety display — a
+>   10× conversion collapse driven by option count alone. The
+>   foundational paper for the paradox-of-choice framing. *Cite with
+>   care: the strong unconditional version of this claim has been
+>   moderated by later meta-analyses (see Counter / nuance).*
+> - **★ [Amershi, Weld, Vorvoreanu, Fourney et al., "Guidelines for Human-AI Interaction," CHI 2019 (Microsoft Research)](https://doi.org/10.1145/3290605.3300233)** —
+>   18 design guidelines distilled from 20+ years of AI UX research
+>   and validated against 20 shipping AI products with 49 design
+>   practitioners. G2 ("make clear why AI did what it did") and G4
+>   ("make clear what the system can and cannot do") name the exact
+>   failure mode of the blank prompt: it communicates neither
+>   capability scope nor recommended action. Institutional
+>   acknowledgment, six years ago, that the blank-cursor surface was
+>   already known to be wrong.
+> - [Hick, "On the Rate of Gain of Information," *Quarterly Journal of Experimental Psychology* 1952](https://journals.sagepub.com/doi/10.1080/17470215208416600) —
+>   The founding experiment: choice reaction time grows as log₂(n+1)
+>   of the number of alternatives. Decision cost scales with option
+>   count. Foundational lab result; the HCI translation needs care
+>   (see Counter / nuance).
+> - [Proctor & Schneider, "Hick's Law for Choice Reaction Time: A Review," *QJEP* 2018](https://web.ics.purdue.edu/~dws/pubs/ProctorSchneider_2018_QJEP.pdf) —
+>   Authoritative 65-year review of follow-on work. The logarithmic
+>   relationship holds across replications, with documented boundary
+>   conditions.
+> - [Jiang et al., "PromptMaker: Prompt-Based Prototyping with Large Language Models," CHI EA 2022](https://dl.acm.org/doi/abs/10.1145/3491101.3503564) —
+>   Qualitative study of 8 designers, PMs, and content strategists
+>   in a 3-week LLM prototyping sprint. Practitioners had to
+>   "reverse-engineer" prompts without examples or scaffolds — they
+>   knew the goal, the surface gave them no path. Supporting context
+>   for the Zamfirescu-Pereira finding.
+> - [Sarkar et al., "Conversational User-AI Intervention: A Study on Prompt Rewriting for Improved LLM Response Generation," ACL 2025](https://arxiv.org/abs/2503.16789) —
+>   Lay users systematically produce suboptimal initial prompts;
+>   automated rewriting measurably improves outcomes. The rewriter
+>   is doing work the interface should have done.
+> - [Liu, "New Users Need Support with Generative-AI Tools," Nielsen Norman Group, March 2024](https://www.nngroup.com/articles/new-AI-users-onboarding/) —
+>   Practitioner research (not peer-reviewed, but NN/G is the
+>   canonical UX publisher). New low-AI-literacy users asked "Why
+>   should I ask questions?" and "Where is the input field?" — the
+>   blank interface communicated nothing about capability or
+>   expected behavior. Broad example prompts substantially
+>   outperformed niche ones for onboarding.
+> - [Norman, *The Design of Everyday Things* (revised 2013)](https://jnd.org/books/the-design-of-everyday-things-revised-and-expanded-edition/) —
+>   Canonical design theory: *affordances* signal action
+>   possibilities; *constraints* narrow the action space to make the
+>   correct action obvious; *forcing functions* prevent error by
+>   making wrong actions impossible. A blank text box affords
+>   everything and constrains nothing — the precise antithesis of
+>   the principle that good design makes the right action legible.
+> - [Loranger, "Simplicity Wins over Abundance of Choice," Nielsen Norman Group 2015](https://www.nngroup.com/articles/simplicity-vs-choice/) —
+>   Coca-Cola Freestyle case study: 100+ flavor combinations
+>   increased task completion time 6× and produced customer
+>   abandonment. Maximally free interfaces paradoxically impede task
+>   completion in the wild.
+>
+> **Counter / nuance — the strong "choice overload" claim is
+> task-conditional, not universal:**
+>
+> - **★ [Scheibehenne, Greifeneder & Todd, "Can There Ever Be Too Many Options? A Meta-Analytic Review of Choice Overload," *Journal of Consumer Research* 2010](https://academic.oup.com/jcr/article-abstract/37/3/409/1827647)** —
+>   63 experimental conditions, N=5,036, mean effect size ≈ 0.
+>   Iyengar-Lepper does not replicate uniformly. The unconditional
+>   version of the paradox-of-choice claim is empirically weak.
+> - **★ [Chernev, Böckenholt & Goodman, "Choice Overload: A Conceptual Review and Meta-Analysis," *Journal of Consumer Psychology* 2015](https://chernev.com/wp-content/uploads/2017/02/ChoiceOverload_JCP_2015.pdf)** —
+>   99 observations. The reconciliation paper: choice overload is
+>   robust *when* four moderators are present — high choice-set
+>   complexity, high decision-task difficulty, high preference
+>   uncertainty, and process-oriented (rather than outcome-oriented)
+>   decision goals. **All four describe a blank LLM prompt.** The
+>   conditional version of the claim is well-supported and is the
+>   one the post should make; the unconditional one is not.
+> - [Liu, Gori, Rioul, Beaudouin-Lafon & Guiard, "How Relevant Is Hick's Law for HCI?" CHI 2020](https://dl.acm.org/doi/abs/10.1145/3313831.3376878) —
+>   Argues Hick's Law does not naively support "fewer options always
+>   wins," and that the stimulus-response paradigm rarely applies
+>   cleanly to HCI tasks where search and recognition dominate. Cite
+>   Hick with this caveat — the load-bearing mechanism is cognitive
+>   load, not stimulus-response timing.
+>
+> **What we deliberately don't lean on — decision fatigue / ego
+> depletion:** The temptation is to write "the blank cursor causes
+> decision fatigue" and reach for Baumeister. The empirical
+> foundation for that mechanism has collapsed under preregistered
+> replication, and we should say so honestly rather than ride a
+> popular metaphor the literature no longer supports.
+>
+> - [Baumeister, Bratslavsky, Muraven & Tice, "Ego Depletion: Is the Active Self a Limited Resource?" *JPSP* 1998](https://doi.org/10.1037/0022-3514.74.5.1252) —
+>   The founding paper for the "willpower / decision fatigue as a
+>   depletable resource" frame.
+> - [Hagger et al., "A Multilab Preregistered Replication of the Ego-Depletion Effect," *Perspectives on Psychological Science* 2016](https://doi.org/10.1177/1745691616652873) —
+>   23 labs, N=2,141, preregistered direct replication. Did not
+>   replicate.
+> - [Vohs et al., "A Multisite Preregistered Paradigmatic Test of the Ego-Depletion Effect," *Psychological Science* 2021](https://pubmed.ncbi.nlm.nih.gov/34520296/) —
+>   36 labs, N=3,531 — the largest test. d=0.06, nonsignificant;
+>   Bayesian evidence ~4× favoring the null. The most definitive
+>   failure-to-replicate to date.
+>
+> The Sweller cognitive-load framing and the Zamfirescu-Pereira CHI
+> evidence do the same explanatory work without the replication
+> risk. Use those.
+>
+> *Evidence gap to acknowledge:* no peer-reviewed A/B study surfaced
+> testing whether suggested-prompt chips, starter cards, or
+> example-prompt scaffolding measurably improve chatbot adoption or
+> task-completion outcomes. The design recommendation (scaffold the
+> blank surface) is supported by cognitive load theory and the
+> *negative* evidence of what fails without scaffolding
+> (Zamfirescu-Pereira, NN/G), not by positive controlled-experiment
+> evidence. The post should say so.
+>
+> *Note for prose drafting:* the clean three-step argument the
+> citations support is — (1) most knowledge work already carries
+> high intrinsic cognitive load (Sweller); (2) a blank prompt loads
+> *extraneous* burden on top of that by forcing the user to
+> construct the problem framing from scratch (Zamfirescu-Pereira;
+> Amershi et al. G2/G4); (3) that cost is real and replicable
+> precisely under the conditions that describe LLM use — high
+> complexity, high preference uncertainty, process-oriented goals
+> (Chernev meta-analysis). The "blinking cursor advertises freedom"
+> line lands because the freedom is paid for in the user's working
+> memory. This block is the *mechanism* under the rest of section 2:
+> the vendor/skills/feature-treadmill tax sits on top of a more
+> fundamental burden the interface imposes the moment the cursor
+> blinks.
 
 > **Evidence — gains skew to novices (the empirical inversion).** The
 > finding originated in 2023 and has now been replicated and
@@ -98,6 +355,10 @@ author: alrubinger
 >   The original 453-person RCT. Foundational but now corroborated by
 >   newer, larger, peer-reviewed work; cite for lineage, not as the
 >   sole prop.
+>
+> - [McKinsey, *State of AI in 2025*](https://www.mckinsey.com/capabilities/quantumblack/our-insights/the-state-of-ai) —
+>   88% of organizations now use AI regularly. The paradigm is not
+>   hype anymore; it's installed base.
 >
 > **Complication worth owning — the novice-gains-more claim is
 > task-conditional, not universal:**

--- a/src/content/posts/more-than-chatbots.mdx
+++ b/src/content/posts/more-than-chatbots.mdx
@@ -45,7 +45,8 @@ That blinking cursor advertises freedom. It delivers friction.
 A freeform text input is the laziest possible interface. It's a tacit 
 admission that "I don't know what you want; literally tell me".
 
-Google got away with it because search started as a conceptually simple 
+Sometimes this is appropriate, or even ideal. Google got away with it because 
+search starts as a conceptually simple 
 interaction. If I want "quick Mexican recipes", I'm eating guac within 
 the hour. I ask for relevant info, I peruse what I want, and I choose 
 one. Interaction over.

--- a/src/content/posts/more-than-chatbots.mdx
+++ b/src/content/posts/more-than-chatbots.mdx
@@ -5,6 +5,9 @@ date: 2026-06-07
 author: alrubinger
 ---
 
+import BlinkingEyes from '@/components/BlinkingEyes.astro';
+import OpinionatedSpectrum from '@/components/OpinionatedSpectrum.astro';
+
 I think AI can be better for teams. Easy to share. Simple to improve. 
 Delightful to use. And friendlier than a blinking cursor in an empty chatbot.
 
@@ -19,35 +22,33 @@ Delightful to use. And friendlier than a blinking cursor in an empty chatbot.
   <span class="cursor-blink absolute left-5 top-1/2 -translate-y-1/2 w-[2px] h-7 bg-foreground"></span>
 </div>
 
-So I want to start there.
-
-Agentic coding may be the greatest software innovation since the web. We're 
-embracing it as a panacea. It is not.
-
-Serious engineers prioritize 
-[first principles thinking](https://en.wikipedia.org/wiki/First_principle) 
-over our excitement and momentum. That's the approach I'll take here.
-
-It's a critique that's a public thought exercise to ground how 
-I want to build differently. I'll ask us to remember respect. Every improvement I want 
-to see in the world is born from what came before.
+So I'll apply 
+[first principles thinking](https://en.wikipedia.org/wiki/First_principle) to
+inspect what makes the chatbot format effective, alluring, and 
+ill-fit for problems of many shapes.
 
 Here we go.
 
 ## The Final Boss of Unopinionated Software
 
-That blinking cursor advertises freedom. It delivers friction.
+Agentic AI may be the grandest software innovation since the web. We gave it a 
+conversational front door, one we're embracing as a panacea. It is not.
 
 <SectionBreak />
 
 ### The Burden of Choice
 
-A freeform text input is the laziest possible interface. It's a tacit 
+For the first time in the history of computing we have software that can 
+conceptually do anything. It makes logical sense that we'd pair it
+with an interface that accepts anything.
+
+At the same time, a single freeform text input is the 
+laziest possible UX. It's a tacit 
 admission that "I don't know what you want; literally tell me".
 
-Sometimes this is appropriate, or even ideal. Google got away with it because 
+Often, this is appropriate. Google gets away with it because 
 search starts as a conceptually simple 
-interaction. If I want "quick Mexican recipes", I'm eating guac within 
+interaction. If I want "quick Mexican recipes", I'm eating homemade guac within 
 the hour. I ask for relevant info, I peruse what I want, and I choose 
 one. Interaction over.
 
@@ -56,34 +57,34 @@ especially when coupled with tooling, are simultaneously extensible and
 powerful. They're the multitool that's a screwdriver, a nail file, 
 and an MRI machine.
 
-For the first time in the history of computing we have software that can 
-conceptually do anything. It made all the sense in the world that we 
-gave it an interface that accepts anything.
-
 But we've [jumped the shark](https://en.wikipedia.org/wiki/Jumping_the_shark).
 
 Because we're prone to a psychological dichotomy. We think we want extreme 
-optionality. We don't.
+optionality. We don't:
 
 <Quote
-    url="https://www.psychologytoday.com/us/blog/more-tech-support/201011/the-burden-choice"
-    articleName="The Burden of Choice: Why choices wreak havoc with happiness."
-    publicationName="Psychology Today"
-    authorName="Frederick J Muench Ph.D."
-    authorX="FredMuench"
-    date="2010-11-01">
+    url="https://psycnet.apa.org/record/2000-16701-012"
+    articleName="When choice is demotivating: Can one desire too much of a good thing?"
+    publicationName="Journal of Personality and Social Psychology"
+    authorName="Iyengar, S. S., & Lepper, M. R"
+    date="2000">
 
-    While subjects initially reported liking having the choice of 30 chocolates, 
-    they ended up being more dissatisfied and regretful of the choices they made 
-    than those who only had the choice of six.
+    The human desire for...choice is unlimited...participants actually 
+    reported greater subsequent satisfaction ... when their original set of 
+    options had been limited.
 </Quote>
 
+That's the OG study on the paradox of choice. It's cited like 3000 times, 
+basically the Beatles' *Yesterday* of academic psychology.
+
 More recent research, admittedly before the agentxplosion of 2025, applies this
-to our use of LLMs and grounds the findings not in happiness but reduced productivity:
+reasoning to our use of LLMs and grounds the findings not in happiness but 
+reduced productivity:
 
 <Quote
     url="https://dl.acm.org/doi/10.1145/3544548.3581388"
     articleName="Why Johnny Can’t Prompt: How Non-AI Experts Try (and Fail) to Design LLM Prompts"
+    publicationName="Association for Computing Machinery"
     authorName="J.D. Zamfirescu-Pereira, Richmond Y. Wong, Bjoern Hartmann, Qian Yang"
     date="2023-04-19">
 
@@ -91,24 +92,25 @@ to our use of LLMs and grounds the findings not in happiness but reduced product
     to make robust, systematic progress. 
 </Quote>
 
-So all this flexibility is making us neither more happy nor more productive. 
-Not a remarkable win for empathetic systems design. And it introduces a more
-acute problem that's stressing people out:
+So all this flexibility in agentic systems is making us neither more happy nor 
+more productive. Not a remarkable win for empathetic systems design. And it 
+introduces a more acute problem that's stressing people out:
 
-It's now up to users to figure out how to use this thing.
+We have to figure out how to use this thing.
 
-### The New Tax
+### The Second Job Tax
 
 The blinky cursor is deceptively complex. You're not just asking an LLM 
-what you type. No no, there's also the MCP servers, available tools,
+what you type. No noes, there's also the available tool descriptions,
 skills, 3rdparty service integrations, `AGENTS.md`/`CLAUDE.md`, 
-rules per folder, per user. 
+rules per folder, per user. And don't forget the features: workflows and 
+subagents and Sites and whatever else lands before I publish this.
 
 Our collective response: better educate people! Get the word out! Trainings, 
 conferences, internal enablement, live-streams! There's a full 
-influence market of newbies ingesting drops from the frontier labs and 
-immediately pumping them into AI-enhanced content machines to 
-redistribute their hard-earned expert insights.
+influence market of professional educators ingesting drops from the frontier 
+labs and immediately pumping them into content machines to 
+broadcast their expert insights.
 
 Here's the problem:
 
@@ -117,14 +119,27 @@ Here's the problem:
     system can absorb. 
 </Callout>
 
-Expecting the workforce to keep pace is a second job layered on top of our
-existing jobs. It's exhausting. And if you're online enough to feel the tension:
-there's a social pressure to be excited about all the opportunity. No one wants 
-to hire or work with a downer in this Reniessance when we've just been 
-gifted the printing press.
+Expecting the workforce to keep pace is a second job. A meta-job, one responsible
+for the efficiency of the first. 
 
-With utmost respect to these innovators, look at what's trending this weekend on 
-how we're asking folks to adopt best practices:
+So much of our narrative now is around the tools. I don't see
+a way around that for the forseeable future. We can all align around the tools, 
+no matter what we're working on. And we all have a lot to figure out together.
+
+Still, it feels like
+tokenmaxxing or screencapping how long you've kept an agent autonomous is 
+overlooking the purpose that brought us to work in the first place.
+
+<Callout>
+    Great guitarists talk about the music. Wannabes talk about the guitar.
+</Callout>
+
+Well, we're at a guitar convention and everyone's a vendor. It's 
+exhausting. And if you're online enough to feel the tension:
+there's pressure to be excited about all the opportunity. No one wants 
+to hire or work with a downer in this Renaissance.
+
+These innovators encouraged folks to adopt best practices:
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-x-10">
   <div>
@@ -137,19 +152,35 @@ how we're asking folks to adopt best practices:
   </div>
 </div>
 
-Gentlemen. <BlinkingEyes /> The product **is** a prompt.
+"*Don't prompt it.*" Gentlemen. <BlinkingEyes /> The product **is** a prompt. 
 
-This is perhaps the strongest signal that the product does not default to 
-the needs of many people.
+Next, Sergey Brin will be telling us not to Google things on Google. 
 
-We're ready to introduce fresher ideas that meet more folks where they 
-are. Less expectation that people conform to the software. Or be 
-Borises or Peters, and hack their own thing to fill the missing pieces.
+So a harness deity and the Clawdfather advise 
+that the product's conversational design works better if you 
+build layers on top of it. I agree.
 
+Takeaways I'm filing:
+
+1. Write software that meets people where they are. Understand a constrained set of problems they want to solve, and offer ways to solve it in the most intuitive manner possible.
+2. Do not require the masses to conform to the software
+3. Most people are not Boris or Peter. Most people want to focus on their first job. 
+
+## Next up: Part Two
+
+### Who Adopts and Who Benefits
+
+<SectionBreak />
+
+<Signature />
 
 ## Themes and emerging narrative
 
+### Take a Stand
 
+Opinionated software.
+
+<OpinionatedSpectrum />
 
 
 ### 2. The hidden cost — a tax on knowledge work

--- a/src/content/posts/more-than-chatbots.mdx
+++ b/src/content/posts/more-than-chatbots.mdx
@@ -8,7 +8,7 @@ author: alrubinger
 import BlinkingEyes from '@/components/BlinkingEyes.astro';
 import OpinionatedSpectrum from '@/components/OpinionatedSpectrum.astro';
 
-I think AI can be better for teams. Easy to share. Simple to improve. 
+I think AI can be better for many teams. Easy to share. Simple to improve. 
 Delightful to use. And friendlier than a blinking cursor in an empty chatbot.
 
 <div class="not-prose my-10 relative" aria-hidden="true">
@@ -22,10 +22,11 @@ Delightful to use. And friendlier than a blinking cursor in an empty chatbot.
   <span class="cursor-blink absolute left-5 top-1/2 -translate-y-1/2 w-[2px] h-7 bg-foreground"></span>
 </div>
 
-So I'll apply 
-[first principles thinking](https://en.wikipedia.org/wiki/First_principle) to
-inspect what makes the chatbot format effective, alluring, and 
-ill-fit for problems of many shapes.
+This isn't the only way to interact with an agent. Many types of work 
+value specificity. 
+
+So I'd like to inspect what makes the chatbot format effective, alluring, and 
+ill-fit for many problems.
 
 Here we go.
 
@@ -33,6 +34,19 @@ Here we go.
 
 Agentic AI may be the grandest software innovation since the web. We gave it a 
 conversational front door, one we're embracing as a panacea. It is not.
+
+The conversational format is a fantastic fit for unopinionated software.
+
+<OpinionatedSpectrum />
+
+Chatbots and agents put you in control. They'll go where you point them.
+
+Most work is more constrained. It has known inputs and outputs. It's meant
+to do one job, and do it well.
+
+This is where repeatable, mundane tasks can be automated. In those cases,
+the arguments for a chatbot make less sense and open the doors for a smoother
+experience interacting with the agent.
 
 <SectionBreak />
 
@@ -47,20 +61,17 @@ laziest possible UX. It's a tacit
 admission that "I don't know what you want; literally tell me".
 
 Often, this is appropriate. Google gets away with it because 
-search starts as a conceptually simple 
+classic search is a conceptually simple 
 interaction. If I want "quick Mexican recipes", I'm eating homemade guac within 
-the hour. I ask for relevant info, I peruse what I want, and I choose 
-one. Interaction over.
+the hour. I ask for relevant info, I choose what I want, and the interaction 
+with search ends.
 
-Agents are a different beast. Prediction engines, 
-especially when coupled with tooling, are simultaneously extensible and 
-powerful. They're the multitool that's a screwdriver, a nail file, 
-and an MRI machine.
+Agents are a different beast. They're the multitool that's a screwdriver, 
+pliars, and an MRI machine. They can do anything we want.
 
-But we've [jumped the shark](https://en.wikipedia.org/wiki/Jumping_the_shark).
+Anything we want. That's why they have [jumped the shark](https://en.wikipedia.org/wiki/Jumping_the_shark).
 
-Because we're prone to a psychological dichotomy. We think we want extreme 
-optionality. We don't:
+We think we want extreme optionality. We don't.
 
 <Quote
     url="https://psycnet.apa.org/record/2000-16701-012"
@@ -139,7 +150,8 @@ exhausting. And if you're online enough to feel the tension:
 there's pressure to be excited about all the opportunity. No one wants 
 to hire or work with a downer in this Renaissance.
 
-These innovators encouraged folks to adopt best practices:
+A recurring narrative in my X feed encourages deeper adoption of 
+conversational models to create software. From this weekend:
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-x-10">
   <div>
@@ -152,23 +164,15 @@ These innovators encouraged folks to adopt best practices:
   </div>
 </div>
 
-"*Don't prompt it.*" Gentlemen. <BlinkingEyes /> The product **is** a prompt. 
+"*Don't prompt it.*" Gentlemen. <BlinkingEyes /> The product **is** a prompt.
 
-Next, Sergey Brin will be telling us not to Google things on Google. 
+This product is not always encouraging the behaviour that makes it most 
+effective.
 
-So a harness deity and the Clawdfather advise 
-that the product's conversational design works better if you 
-build layers on top of it. I agree.
+## Who Adopts and Who Benefits
 
-Takeaways I'm filing:
+The folks who benefit the most from AI are those more resistant to learning it.
 
-1. Write software that meets people where they are. Understand a constrained set of problems they want to solve, and offer ways to solve it in the most intuitive manner possible.
-2. Do not require the masses to conform to the software
-3. Most people are not Boris or Peter. Most people want to focus on their first job. 
-
-## Next up: Part Two
-
-### Who Adopts and Who Benefits
 
 <SectionBreak />
 
@@ -178,19 +182,8 @@ Takeaways I'm filing:
 
 ### Take a Stand
 
-Opinionated software.
-
-<OpinionatedSpectrum />
-
 
 ### 2. The hidden cost — a tax on knowledge work
-
-> *"We're seeing everything through the lens of this prompt, this
-> empty blinking cursor we can type anything through… In addition to
-> doing your job, now you need to get good at these new tools and
-> you need to stay plugged in, and you need to be learning with
-> routine the latest that's coming down the pike, and that's
-> exhausting."*
 
 - Two responses, oversimplified — but careful here, the obvious
   framing is wrong:
@@ -206,260 +199,14 @@ Opinionated software.
   complaint. It's the toll booth between the people who would gain
   most from AI and the gains themselves.
 
-> **Evidence — the blank cursor *is* the tax (burden of choice as the
-> structural mechanism).** The tax this section describes doesn't
-> begin with vendors and features — it begins one layer earlier, at
-> the prompt itself. A maximally free interface forces the user to
-> invent the problem framing before they can begin the work. The
-> blinking cursor advertises freedom; the user pays for that freedom
-> in working memory. Decades of cognitive psychology and HCI research
-> describe what that costs.
+> **Evidence:**
 >
-> - **★ [Zamfirescu-Pereira, Wong, Hartmann & Yang, "Why Johnny Can't Prompt: How Non-AI Experts Try (and Fail) to Design LLM Prompts," CHI 2023](https://doi.org/10.1145/3544548.3581388)** —
->   The load-bearing empirical source for the blank-prompt problem.
->   10 non-expert participants using an LLM-prompt design probe
->   explored opportunistically rather than systematically,
->   generalized incorrectly from human-to-human conversational norms,
->   and failed to make "robust, systematic progress." The open-ended
->   interface was the structural source of the struggle — not the
->   model. *This is what lets us name the blinking cursor itself as
->   the tax.*
-> - **★ [Sweller, van Merriënboer & Paas, "Cognitive Architecture and Instructional Design," *Educational Psychology Review* 1998](https://link.springer.com/article/10.1023/A:1022193728205)** —
->   The canonical formulation of *intrinsic / extraneous / germane*
->   cognitive load. The user's actual knowledge-work problem is the
->   intrinsic load — already high. A blank prompt loads on top of
->   that an *extraneous* burden — how to phrase the ask, what the
->   system can do, where to begin — that a well-designed interface
->   would offload to scaffolds. Builds on the founding paper,
->   [Sweller, *Cognitive Science* 1988](https://onlinelibrary.wiley.com/doi/10.1207/s15516709cog1202_4).
-> - **★ [Iyengar & Lepper, "When Choice Is Demotivating: Can One Desire Too Much of a Good Thing?" *Journal of Personality and Social Psychology* 2000](https://psycnet.apa.org/record/2000-16701-012)** —
->   The "jam study" (and replication across chocolate and essay
->   prompts). A 24-variety display attracted more browsers but
->   produced a 3% purchase rate vs. 30% from a 6-variety display — a
->   10× conversion collapse driven by option count alone. The
->   foundational paper for the paradox-of-choice framing. *Cite with
->   care: the strong unconditional version of this claim has been
->   moderated by later meta-analyses (see Counter / nuance).*
-> - **★ [Amershi, Weld, Vorvoreanu, Fourney et al., "Guidelines for Human-AI Interaction," CHI 2019 (Microsoft Research)](https://doi.org/10.1145/3290605.3300233)** —
->   18 design guidelines distilled from 20+ years of AI UX research
->   and validated against 20 shipping AI products with 49 design
->   practitioners. G2 ("make clear why AI did what it did") and G4
->   ("make clear what the system can and cannot do") name the exact
->   failure mode of the blank prompt: it communicates neither
->   capability scope nor recommended action. Institutional
->   acknowledgment, six years ago, that the blank-cursor surface was
->   already known to be wrong.
-> - [Hick, "On the Rate of Gain of Information," *Quarterly Journal of Experimental Psychology* 1952](https://journals.sagepub.com/doi/10.1080/17470215208416600) —
->   The founding experiment: choice reaction time grows as log₂(n+1)
->   of the number of alternatives. Decision cost scales with option
->   count. Foundational lab result; the HCI translation needs care
->   (see Counter / nuance).
-> - [Proctor & Schneider, "Hick's Law for Choice Reaction Time: A Review," *QJEP* 2018](https://web.ics.purdue.edu/~dws/pubs/ProctorSchneider_2018_QJEP.pdf) —
->   Authoritative 65-year review of follow-on work. The logarithmic
->   relationship holds across replications, with documented boundary
->   conditions.
-> - [Jiang et al., "PromptMaker: Prompt-Based Prototyping with Large Language Models," CHI EA 2022](https://dl.acm.org/doi/abs/10.1145/3491101.3503564) —
->   Qualitative study of 8 designers, PMs, and content strategists
->   in a 3-week LLM prototyping sprint. Practitioners had to
->   "reverse-engineer" prompts without examples or scaffolds — they
->   knew the goal, the surface gave them no path. Supporting context
->   for the Zamfirescu-Pereira finding.
-> - [Sarkar et al., "Conversational User-AI Intervention: A Study on Prompt Rewriting for Improved LLM Response Generation," ACL 2025](https://arxiv.org/abs/2503.16789) —
->   Lay users systematically produce suboptimal initial prompts;
->   automated rewriting measurably improves outcomes. The rewriter
->   is doing work the interface should have done.
-> - [Liu, "New Users Need Support with Generative-AI Tools," Nielsen Norman Group, March 2024](https://www.nngroup.com/articles/new-AI-users-onboarding/) —
->   Practitioner research (not peer-reviewed, but NN/G is the
->   canonical UX publisher). New low-AI-literacy users asked "Why
->   should I ask questions?" and "Where is the input field?" — the
->   blank interface communicated nothing about capability or
->   expected behavior. Broad example prompts substantially
->   outperformed niche ones for onboarding.
-> - [Norman, *The Design of Everyday Things* (revised 2013)](https://jnd.org/books/the-design-of-everyday-things-revised-and-expanded-edition/) —
->   Canonical design theory: *affordances* signal action
->   possibilities; *constraints* narrow the action space to make the
->   correct action obvious; *forcing functions* prevent error by
->   making wrong actions impossible. A blank text box affords
->   everything and constrains nothing — the precise antithesis of
->   the principle that good design makes the right action legible.
-> - [Loranger, "Simplicity Wins over Abundance of Choice," Nielsen Norman Group 2015](https://www.nngroup.com/articles/simplicity-vs-choice/) —
->   Coca-Cola Freestyle case study: 100+ flavor combinations
->   increased task completion time 6× and produced customer
->   abandonment. Maximally free interfaces paradoxically impede task
->   completion in the wild.
->
-> **Counter / nuance — the strong "choice overload" claim is
-> task-conditional, not universal:**
->
-> - **★ [Scheibehenne, Greifeneder & Todd, "Can There Ever Be Too Many Options? A Meta-Analytic Review of Choice Overload," *Journal of Consumer Research* 2010](https://academic.oup.com/jcr/article-abstract/37/3/409/1827647)** —
->   63 experimental conditions, N=5,036, mean effect size ≈ 0.
->   Iyengar-Lepper does not replicate uniformly. The unconditional
->   version of the paradox-of-choice claim is empirically weak.
-> - **★ [Chernev, Böckenholt & Goodman, "Choice Overload: A Conceptual Review and Meta-Analysis," *Journal of Consumer Psychology* 2015](https://chernev.com/wp-content/uploads/2017/02/ChoiceOverload_JCP_2015.pdf)** —
->   99 observations. The reconciliation paper: choice overload is
->   robust *when* four moderators are present — high choice-set
->   complexity, high decision-task difficulty, high preference
->   uncertainty, and process-oriented (rather than outcome-oriented)
->   decision goals. **All four describe a blank LLM prompt.** The
->   conditional version of the claim is well-supported and is the
->   one the post should make; the unconditional one is not.
-> - [Liu, Gori, Rioul, Beaudouin-Lafon & Guiard, "How Relevant Is Hick's Law for HCI?" CHI 2020](https://dl.acm.org/doi/abs/10.1145/3313831.3376878) —
->   Argues Hick's Law does not naively support "fewer options always
->   wins," and that the stimulus-response paradigm rarely applies
->   cleanly to HCI tasks where search and recognition dominate. Cite
->   Hick with this caveat — the load-bearing mechanism is cognitive
->   load, not stimulus-response timing.
->
-> **What we deliberately don't lean on — decision fatigue / ego
-> depletion:** The temptation is to write "the blank cursor causes
-> decision fatigue" and reach for Baumeister. The empirical
-> foundation for that mechanism has collapsed under preregistered
-> replication, and we should say so honestly rather than ride a
-> popular metaphor the literature no longer supports.
->
-> - [Baumeister, Bratslavsky, Muraven & Tice, "Ego Depletion: Is the Active Self a Limited Resource?" *JPSP* 1998](https://doi.org/10.1037/0022-3514.74.5.1252) —
->   The founding paper for the "willpower / decision fatigue as a
->   depletable resource" frame.
-> - [Hagger et al., "A Multilab Preregistered Replication of the Ego-Depletion Effect," *Perspectives on Psychological Science* 2016](https://doi.org/10.1177/1745691616652873) —
->   23 labs, N=2,141, preregistered direct replication. Did not
->   replicate.
-> - [Vohs et al., "A Multisite Preregistered Paradigmatic Test of the Ego-Depletion Effect," *Psychological Science* 2021](https://pubmed.ncbi.nlm.nih.gov/34520296/) —
->   36 labs, N=3,531 — the largest test. d=0.06, nonsignificant;
->   Bayesian evidence ~4× favoring the null. The most definitive
->   failure-to-replicate to date.
->
-> The Sweller cognitive-load framing and the Zamfirescu-Pereira CHI
-> evidence do the same explanatory work without the replication
-> risk. Use those.
->
-> *Evidence gap to acknowledge:* no peer-reviewed A/B study surfaced
-> testing whether suggested-prompt chips, starter cards, or
-> example-prompt scaffolding measurably improve chatbot adoption or
-> task-completion outcomes. The design recommendation (scaffold the
-> blank surface) is supported by cognitive load theory and the
-> *negative* evidence of what fails without scaffolding
-> (Zamfirescu-Pereira, NN/G), not by positive controlled-experiment
-> evidence. The post should say so.
->
-> *Note for prose drafting:* the clean three-step argument the
-> citations support is — (1) most knowledge work already carries
-> high intrinsic cognitive load (Sweller); (2) a blank prompt loads
-> *extraneous* burden on top of that by forcing the user to
-> construct the problem framing from scratch (Zamfirescu-Pereira;
-> Amershi et al. G2/G4); (3) that cost is real and replicable
-> precisely under the conditions that describe LLM use — high
-> complexity, high preference uncertainty, process-oriented goals
-> (Chernev meta-analysis). The "blinking cursor advertises freedom"
-> line lands because the freedom is paid for in the user's working
-> memory. This block is the *mechanism* under the rest of section 2:
-> the vendor/skills/feature-treadmill tax sits on top of a more
-> fundamental burden the interface imposes the moment the cursor
-> blinks.
-
-> **Evidence — gains skew to novices (the empirical inversion).** The
-> finding originated in 2023 and has now been replicated and
-> peer-reviewed across multiple domains in 2025–2026:
->
-> - **★ [Brynjolfsson, Li & Raymond, *QJE* May 2025](https://academic.oup.com/qje/article/140/2/889/7990658)** —
->   The canonical citation. The 2023 NBER paper formally published in
->   *Quarterly Journal of Economics*: 5,172 support agents,
->   bottom-quintile workers gained 34–36%, top performers near zero.
-> - **★ [Cui, Demirer, Peng et al., *Management Science* 2025/26](https://pubsonline.informs.org/doi/10.1287/mnsc.2025.00535)** —
->   Three RCTs across Microsoft, Accenture, and a Fortune 100 firm;
->   4,867 software developers; AI coding assistant. 26% average
->   completed-task increase. Less experienced developers had *both*
->   higher adoption *and* larger productivity gains. Direct
->   replication of the pattern in coding.
-> - **★ [Dell'Acqua et al., "Navigating the Jagged Technological Frontier," *Organization Science* March 2026](https://pubsonline.informs.org/doi/10.1287/orsc.2025.21838)** —
->   758 BCG consultants, GPT-4. Inside-frontier tasks: 30–40% quality
->   gains, bottom-half performers showed "substantially larger
->   relative gains." Outside-frontier: correctness *dropped* 19pp for
->   AI users. Same compression pattern, with task-type caveat.
-> - [Fruits & Stout, *AI, Productivity, and Labor Markets* (ICLE Feb 2026)](https://laweconcenter.org/resources/ai-productivity-and-labor-markets-a-review-of-the-empirical-evidence/) —
->   Meta-review of micro-level RCTs. Skill compression is the
->   dominant finding across studies. Notes Merali (2024): lower-skill
->   translators gained ~4× more than higher-skill peers.
-> - [Stray et al., longitudinal Copilot case study, arXiv Jan 2026](https://arxiv.org/abs/2509.20353) —
->   Norwegian public-sector developers, commit-level metrics +
->   interviews. Greatest gains among less experienced devs; seniors
->   muted or mixed.
-> - [Noy & Zhang, *Science* 2023](https://www.science.org/doi/10.1126/science.adh2586) —
->   The original 453-person RCT. Foundational but now corroborated by
->   newer, larger, peer-reviewed work; cite for lineage, not as the
->   sole prop.
->
-> - [McKinsey, *State of AI in 2025*](https://www.mckinsey.com/capabilities/quantumblack/our-insights/the-state-of-ai) —
->   88% of organizations now use AI regularly. The paradigm is not
->   hype anymore; it's installed base.
->
-> **Complication worth owning — the novice-gains-more claim is
-> task-conditional, not universal:**
->
-> - **★ [METR — "Measuring the Impact of Early-2025 AI on Experienced Open-Source Developer Productivity," July 2025](https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/)** —
->   RCT, 16 experienced open-source developers, 246 real repository
->   tasks. Allowing AI *increased* completion time by 19%. Developers
->   predicted 20% savings — they were directionally wrong. Mechanism:
->   deep repo familiarity, large legacy codebases, low AI acceptance
->   rate (~44%). The sharper read: AI helps novices on *standardized*
->   tasks; it can actively harm experts on *complex, idiosyncratic*
->   work. The post should acknowledge this rather than overclaim.
-> - [Riedl & Bogert, "Effects of AI Feedback on Learning, the Skill Gap, and Intellectual Diversity," arXiv Sep 2024](https://arxiv.org/abs/2409.18660) —
->   52,000 chess players, 42 platform natural experiments. Higher-skill
->   players seek AI feedback strategically; lower-skill players seek
->   it after wins (counterproductive). Over time, AI access *widened*
->   the skill gap rather than compressing it. About *learning*
->   dynamics, not task completion — but worth knowing.
->
-> **Evidence — the adoption tax is real and falls hardest on the
-> laggards:**
->
-> - **★ [BCG, *AI at Work 2025*](https://www.bcg.com/publications/2025/ai-at-work-momentum-builds-but-gaps-remain)** —
->   10,600+ workers, 11 countries. Only 36% say training is enough;
->   18% of regular AI users got *no training at all*; 54% would use
->   unauthorized tools ("shadow AI"); only 33% understand what AI
->   agents are.
-> - **★ [Fortune/ManpowerGroup, "AI Workers' Toxic Relationship," Jan 2026](https://fortune.com/2026/01/21/ai-workers-toxic-relationship-trust-confidence-collapses-training-manpower-group/)** —
->   Regular AI users up 13% in 2025; confidence in AI *collapsed 18%*.
->   Sharpest drop among older / lower-digital-literacy cohorts
->   (Boomers −35%, Gen X −25%). The workers most likely to gain are
->   the workers most likely to distrust and under-use. **This is the
->   new load-bearing data point for the access argument.**
-> - [McKinsey, *Redefine AI Upskilling as Change Imperative*](https://www.mckinsey.com/capabilities/people-and-organizational-performance/our-insights/the-organization-blog/redefine-ai-upskilling-as-a-change-imperative) —
->   9 in 10 workers say training would help; 7 in 10 *ignored* the
->   onboarding videos and learned by trial-and-error while doing
->   their actual jobs.
-> - [The Emerging GenAI Divide in the US, arXiv 2024](https://arxiv.org/abs/2404.11988) —
->   ChatGPT adoption clusters in coastal, educated, high-income
->   metros. Risks reinforcing existing divides — *at the adoption
->   layer, not the capability layer.*
->
-> **Counter / nuance:**
->
-> - [Dillon, Jaffe, Immorlica, Stanton, NBER w33795, May 2025](https://www.nber.org/papers/w33795) —
->   Largest enterprise field study to date: 66 firms, 7,137 workers,
->   Microsoft 365 Copilot, six months. ~2 hrs/week saved on email
->   (−31%), reduced outside-hours work, but *no detectable shift in
->   task composition.* Aggregate field effects are smaller than RCT
->   effects — the lab/field gap is itself a data point about
->   adoption.
-> - [Brynjolfsson "harvest phase," *Fortune* Feb 2026](https://fortune.com/2026/02/15/ai-productivity-liftoff-doubling-2025-jobs-report-transition-harvest-phase-j-curve/) —
->   US productivity grew ~2.7% in 2025, nearly double the decade
->   average. Brynjolfsson himself now says the J-curve is bending up.
->   The macro payoff is arriving — for the orgs that figured out
->   adoption.
-> - [Brynjolfsson, Rock & Syverson, NBER 2021 (w25148)](https://www.nber.org/papers/w25148) —
->   The J-curve framework: productivity *appears* flat during
->   adoption because complementary intangibles are being built.
->   Useful frame for "this is hard, not broken."
->
-> *Note for prose drafting:* the consensus has firmed up (multiple
-> 2025–2026 peer-reviewed replications), but the complications matter
-> — the inversion is real for standardized knowledge work and breaks
-> down for expert-domain work (METR) and for learning-over-time
-> (Riedl & Bogert). The honest framing: AI compresses the capability
-> gap on *most knowledge tasks*, and the chatbot interface is the
-> adoption barrier keeping that compression from reaching the
-> workers it would help most.
+> - **[Brynjolfsson, Li & Raymond, "Generative AI at Work," *Quarterly Journal of Economics* May 2025](https://academic.oup.com/qje/article/140/2/889/7990658)** —
+>   5,172 support agents. Bottom-quintile workers gained 34–36%; top
+>   performers near zero. AI compresses the capability gap on
+>   knowledge work — and the chatbot interface is the adoption
+>   barrier keeping that compression from reaching the workers it
+>   would help most.
 
 ### 2.5. The engagement design is not accidental
 
@@ -494,56 +241,16 @@ use patterns — not "it hits your dopamine." We should say so
 plainly. Overclaiming on neuroscience costs more credibility than
 "addictive" buys.
 
-> **Evidence — engagement is selected for in training:**
+> **Evidence:**
 >
-> - **★ [Sharma et al., "Towards Understanding Sycophancy in Language Models," ICLR 2024 (Anthropic)](https://arxiv.org/abs/2310.13548)** —
+> - **[Sharma et al., "Towards Understanding Sycophancy in Language Models," ICLR 2024 (Anthropic)](https://arxiv.org/abs/2310.13548)** —
 >   Empirical analysis across five advanced AI assistants. Sycophancy
 >   — preferring user-belief-matching responses over truthful ones —
 >   is a general property of RLHF-trained models. Human raters
 >   preferred convincing sycophantic responses to correct ones "a
 >   non-negligible fraction of the time." Optimizing against
 >   preference models sometimes sacrifices truthfulness for
->   agreement. *This is the load-bearing source for the "engineered
->   for stickiness" claim.*
-> - [How RLHF Amplifies Sycophancy, arXiv April 2025](https://arxiv.org/html/2602.01002v1) —
->   Sycophancy often intensifies *after* preference-based
->   post-training. The effect grows with optimization, not in spite
->   of it.
->
-> **Evidence — heavy use produces measurable problematic-use
-> patterns:**
->
-> - **★ [Naycı et al., "Problematic ChatGPT Use Scale," *International Journal of Mental Health and Addiction* (Springer) 2025](https://link.springer.com/article/10.1007/s11469-025-01509-y)** —
->   Two-study validation, n=864. A reliable 9-item unidimensional
->   scale for problematic ChatGPT use. PCGU scores correlate
->   positively with AI addiction, internet gaming disorder, and
->   internet addiction; negatively with conscientiousness;
->   psychological distress and self-control mediate the
->   PCGU-wellbeing relationship. **The first methodologically rigorous
->   LLM-specific clinical instrument** — and the closest support yet
->   for calling chatbots "addictive" in any clinical sense.
-> - [Fang et al. (MIT Media Lab / OpenAI), "How AI and Human Behaviors Shape Psychosocial Effects of Extended Chatbot Use," March 2025](https://www.media.mit.edu/publications/how-ai-and-human-behaviors-shape-psychosocial-effects-of-chatbot-use-a-longitudinal-controlled-study/) —
->   Two-pronged: ~40M real-world ChatGPT interactions + ~1,000-person
->   RCT over four weeks. Higher daily usage correlated with
->   loneliness, emotional dependence, and indicators of problematic
->   use. *This is OpenAI's own research arm finding it.*
->
-> **Counter / nuance — the "addiction" frame is contested:**
->
-> - [Montag et al., "The Role of AI and LLMs for Understanding Addictive Behaviors," *Annals of the New York Academy of Sciences*, April 2025](https://pmc.ncbi.nlm.nih.gov/articles/PMC12220279/) —
->   Addiction researchers themselves prefer "over-reliance" and
->   "cognitive outsourcing" to "addiction" for LLMs. The clinical
->   construct may be too narrow.
-> - Effects are strongly moderated by use case. Companionship and
->   roleplay use show the sharpest harm signal; information and
->   productivity use carry a different risk profile. The post should
->   make clear we're talking about engagement-design risk in
->   knowledge-work contexts, not equating ChatGPT with Replika.
->
-> *Evidence gap to own:* no fMRI or direct neurochemical study on
-> LLM use exists as of mid-2026. The "dopamine" framing is borrowed
-> metaphor. The defensible claim is engagement-optimized training +
-> validated problematic-use scale, not neuroscience.
+>   agreement.
 
 ### 3. The missing infrastructure — why this work doesn't compound
 
@@ -578,48 +285,16 @@ plainly. Overclaiming on neuroscience costs more credibility than
   capability gains to land at the organization level, and the
   current interface blocks both.
 
-> **Evidence — even with real individual gains, org-level work
-> doesn't restructure:**
+> **Evidence:**
 >
-> - **★ [Dillon, Jaffe, Immorlica, Stanton, NBER w33795, May 2025](https://www.nber.org/papers/w33795)** —
+> - **[Dillon, Jaffe, Immorlica, Stanton, NBER w33795, May 2025](https://www.nber.org/papers/w33795)** —
 >   Largest enterprise field study to date: 66 firms, 7,137 workers,
 >   Microsoft 365 Copilot, six months. Workers saved ~2 hrs/week on
 >   email (−31%) and reduced after-hours work — but the study
 >   reports *no detectable shifts in the quantity or composition of
->   workers' tasks.* Time was reclaimed; work wasn't restructured.
->   Exactly the pattern the "unit of value is a conversation, not a
->   capability" framing predicts: individual gains accrued; the
->   shape of org-level work stayed put. (Cross-listed from theme 2,
->   where the same finding plays a *counter* role on the
->   productivity story; here it plays a *supporting* role on the
->   doesn't-compound claim. Same data, two things to say with it.)
->
-> **Evidence — standards are still immature:**
->
-> - **★ ["Is MCP Dead?", Claude Directory Blog 2026](https://www.claudedirectory.org/blog/is-mcp-dead)** —
->   Five persistent weaknesses: conceptual overhead (JSON-RPC +
->   transports + capability negotiation), no curated registry with
->   verified publishers, inconsistent auth, sandboxing gaps, and "the
->   gap between 'I want my AI to do a thing' and 'I have a working
->   MCP server' is still too wide."
-> - [AI Interoperability Challenges, arXiv Jan 2026](https://arxiv.org/pdf/2601.14512) —
->   MCP, A2A, ACP and others in an "AI protocol war"; orgs build
->   integration layers that negate the interop benefit.
-> - [Palo Alto Networks on MCP security](https://live.paloaltonetworks.com/t5/community-blogs/mcp-security-exposed-what-you-need-to-know-now/ba-p/1227143) —
->   MCP designed for interop, not security. Plaintext credentials,
->   tool poisoning, prompt injection. Multiple independent security
->   firms converge on the same gap.
->
-> **Counter / nuance — standards are maturing fast:**
->
-> - [MCP first anniversary / Linux Foundation donation, Dec 2025](https://blog.modelcontextprotocol.io/posts/2025-11-25-first-mcp-anniversary/) —
->   97M monthly SDK downloads, 10,000+ active servers,
->   OpenAI/Microsoft/Google adoption. Anthropic donated MCP
->   governance to the Linux Foundation alongside Kubernetes and
->   PyTorch.
-> - [Anthropic + OpenAI MCP Apps Extension](https://inkeep.com/blog/anthropic-openai-mcp-apps-extension) —
->   Joint extension for interactive AI interfaces. Cross-vendor
->   convergence cuts against the fragmentation narrative.
+>   workers' tasks.* Time was reclaimed; work wasn't restructured —
+>   exactly the pattern the "unit of value is a conversation, not a
+>   capability" framing predicts.
 
 ### 4. The structural critique — chatbots are wrong for what we're using them for
 
@@ -650,31 +325,15 @@ on.
 
 > **Evidence:**
 >
-> - **★ Nardi, *A Small Matter of Programming* (MIT Press 1993).**
+> - **Nardi, *A Small Matter of Programming* (MIT Press 1993).**
 >   The foundational text on end-user computing. The most-cited
 >   sentence in the book is also the one that lands hardest here:
 >
 >   > *"the problem with programming is not programming; it is the
 >   > languages in which people are asked to program."* (loc. 478)
 >
->   And on what *task-specific* languages buy that general-purpose
->   ones don't:
->
->   > *"it affords users ready understanding of what the primitives
->   > of the language do 'because they already know them from their
->   > task domain', and it eases application development because
->   > users can directly express domain semantics in the high-level
->   > operations of the language — there is no need to string
->   > together lower-level operations to get the desired behavior."*
->   > (loc. 470)
->
 >   The chatbot is the opposite move: one infinitely-general surface
->   for every task. Nardi's full programmatic claim — that "end users
->   will freely write their own applications when they have
->   task-specific programming languages embedded in appropriate
->   visual frameworks" (loc. 53) — extends directly into theme 5,
->   with an important nuance about *how* the author/executor
->   boundary should be dissolved.
+>   for every task.
 >
 >   Verification: the MIT Press edition is paywalled, but
 >   [Gien Verschatse's reading notes](https://www.gienverschatse.com/books/2018/12/09/a-small-matter/)
@@ -696,41 +355,11 @@ work.
 
 > **Evidence:**
 >
-> - **★ [The Keyhole Effect, arXiv Feb 2025](https://arxiv.org/abs/2602.00947)** —
+> - **[The Keyhole Effect, arXiv Feb 2025](https://arxiv.org/abs/2602.00947)** —
 >   Mohan Reddy. Chat imposes a "keyhole effect": users see only a
 >   narrow, sequential slice when analysis needs spatial, parallel
 >   views. Invokes Miller's working-memory limits. Directly names
 >   the structural problem the transcript is describing.
-> - [Cognitive Load and Human-Chatbot Interaction, arXiv 2021](https://arxiv.org/pdf/2111.01400) —
->   Experimental: chatbots produce *higher* cognitive load and lower
->   perceived autonomy than structured interfaces.
-> - [Nielsen Norman Group on chatbot UX](https://blog.experientia.com/nielsen-norman-group-on-the-user-experience-of-chatbots/) —
->   Chatbots "work well only for very limited, simple queries." 425
->   ChatGPT/Bard/Bing interactions surfaced six distinct conversation
->   types needing different interface models. One UI shape fits none.
-> - [Mohebbi, "Dark Ages of Usability," *UX Collective*](https://uxdesign.cc/why-conversational-interfaces-are-taking-us-back-to-the-dark-ages-of-usability-fa45fefb446b) —
->   Practitioner critique: chat regresses decades of UI progress;
->   discoverability collapses, affordances vanish, query-formulation
->   burden shifts to the user.
-> - [Erika Hall, *Conversational Design*, A Book Apart 2018](https://www.braintraffic.com/podcast/ep-1-erika-hall-and-conversational-design) —
->   Good conversational design requires understanding human
->   conversation principles (turn-taking, repair, context), not just
->   shipping a text box.
->
-> *Evidence gap to acknowledge:* the NN/G and Erika Hall material
-> predates LLMs. The strongest LLM-specific structural critique is
-> the Keyhole Effect paper. Lean on it and be honest about the gap.
->
-> **Counter / nuance:**
->
-> - [Multi-Turn Interactions Survey, arXiv April 2025](https://arxiv.org/abs/2504.04717) —
->   Acknowledges failure modes but argues they're solvable
->   engineering problems. Larger context + memory architectures may
->   close the gap.
-> - [Large Language User Interfaces, arXiv 2024](https://arxiv.org/html/2402.07938v2) —
->   LLM-powered conversational interfaces now handle natural
->   variation better than rule-based predecessors; some NN/G-era
->   critiques may be partially obsolete.
 
 **c. Wrong return form.** Conversation isn't a render format. Most
 work has a natural shape — a map for places, a table for comparison,
@@ -764,31 +393,12 @@ Same model behind both. The difference is whether we make the user
 reconstruct meaning from prose, or render the work in the shape the
 work already has.
 
-> **Evidence — generative UIs already beat chat on preference:**
+> **Evidence:**
 >
-> - **★ [Generative Interfaces for Language Models, arXiv 2025](https://arxiv.org/abs/2508.19227)** —
+> - **[Generative Interfaces for Language Models, arXiv 2025](https://arxiv.org/abs/2508.19227)** —
 >   Up to 72% human preference improvement for LLM-generated UIs over
 >   chat on information-dense / exploratory tasks. Frames chat as
 >   fundamentally constrained by "linear request-response format."
-> - [Vercel AI SDK 3.0 — Generative UI](https://vercel.com/blog/ai-sdk-3-generative-ui) —
->   Production-grade, 20M+ monthly downloads. Frames it as "infinite
->   ephemeral interfaces" — every query gets a custom UI.
-> - [Google A2UI](https://developers.googleblog.com/introducing-a2ui-an-open-project-for-agent-driven-interfaces/) —
->   Open project for interoperable agent-driven interfaces. Cites
->   Google research finding users preferred AI-generated HTML/CSS/JS
->   over markdown 83% of the time.
->
-> **Counter / nuance — generative UIs have a real reliability
-> ceiling:**
->
-> - [Anthropic computer-use reliability](https://www.financialcontent.com/article/tokenring-2025-12-30-the-rise-of-the-digital-intern-how-anthropics-computer-use-redefined-the-ai-agent-landscape) —
->   14.9% on screenshot-only tasks at Oct 2024 launch. Even by late
->   2025, "hallucination drift" in 100-step tasks remains.
->   Hallucinated clicks required human-in-the-loop guardrails.
-> - [Software as Content, arXiv March 2026](https://arxiv.org/abs/2603.21334) —
->   When the interface itself is generated, users lose the stable
->   visual anchor they use to detect errors. Dynamic UIs are harder
->   to audit.
 
 ### 5. The collapsed roles — author vs. executor (and the chatbot's false dissolution)
 
@@ -819,59 +429,22 @@ work already has.
 
 > **Evidence:**
 >
-> - **★ Nardi, *A Small Matter of Programming* (MIT Press 1993) —
->   the layered model.** Nardi identifies four user tiers — systems
->   programmers, translators, *local developers* ("the 10–20 percent
->   of every end-user group" who customize tools for their
->   colleagues), and end users — and argues that successful tools
->   support the collaboration between layers. On why collapsing
->   without the right tools is inefficient:
->
->   > *"The process of transferring domain knowledge to a programmer,
->   > and going through the necessary iterations to get the desired
->   > application, is inefficient."* (loc. 1495)
->
->   And the load-bearing nuance — Nardi's *aspirational* position
->   isn't "preserve the boundary." It's:
+> - **Nardi, *A Small Matter of Programming* (MIT Press 1993) —
+>   the layered model.** Nardi's aspirational position isn't
+>   "preserve the boundary" between author and executor — it's:
 >
 >   > *"with the right tools, abolish the distinction between 'end
 >   > user' and 'programmer.'"* (loc. 1607)
 >
->   Read together with theme 4a's quotes on task-specific languages:
 >   Nardi wants the author/executor boundary dissolved, but dissolved
 >   *by giving domain experts their own task-shaped language*, not
 >   by collapsing everyone into a single general-purpose surface.
->   The chatbot does the second. That's the *false dissolution* the
->   bullet above is naming, and Nardi's framework is what makes the
->   critique precise rather than reactionary.
 >
 >   Verification:
 >   [Verschatse reading notes](https://www.gienverschatse.com/books/2018/12/09/a-small-matter/)
 >   and [Millspaugh notes](https://www.petemillspaugh.com/a-small-matter-of-programming)
 >   reproduce verbatim quotes with Kindle locations and print page
 >   numbers respectively.
->
-> - [PUMICE / Sugilite, CMU Natural Programming, UIST 2019](https://www.cs.cmu.edu/~NatProg/sugilite.html) —
->   Brad Myers group. Multi-modal agent for end-user programmers,
->   *explicitly* separating the authoring phase (teach the agent)
->   from the execution phase (run the task).
-> - [n8n vs. Zapier design philosophy, Hatchworks 2026](https://hatchworks.com/blog/ai-agents/n8n-vs-zapier/) —
->   Zapier targets citizen developers (authoring); n8n targets
->   technical users (execution control, self-hosting). Two thriving
->   tools institutionalizing the role split.
-> - [Workflow Governance at Scale, Medium 2025](https://medium.com/@bhagyarana80/workflow-governance-at-scale-iac-policy-for-n8n-zapier-0a790697ccd5) —
->   Treat automation definitions as code artifacts (Git, versioned,
->   reviewed), then *deploy* into execution environments. Emerging
->   best practice.
->
-> **Counter / nuance — the distinction may be collapsing:**
->
-> - [Eric Ma, "Rethinking LLM Interfaces," June 2025](https://ericmjl.github.io/blog/2025/6/14/rethinking-llm-interfaces-from-chatbots-to-contextual-applications/) —
->   Modern LLM agents can author *and* execute on the fly; the
->   define-then-run architecture may be unnecessary overhead.
-> - [InstructPipe, arXiv 2023](https://arxiv.org/abs/2312.09672) —
->   LLMs generate pipeline definitions from natural language,
->   blurring the authoring/execution boundary directly.
 
 ### 6. External signal — we're not the only voice in this position
 
@@ -896,28 +469,9 @@ noting that the position isn't ours alone.
 
 > **Evidence:**
 >
-> - **★ [Chesky on TBPN, May 8 2026 (via Benzinga)](https://www.benzinga.com/news/topics/26/05/52847666/airbnb-ceo-brian-chesky-chatbots-are-not-the-future-of-ai-consumer-products-are)** —
->   The exact quote and full context.
-> - [Chesky starting an AI company, *Fortune* June 4 2026](https://fortune.com/2026/06/04/airbnb-ceo-brian-chesky-plans-to-start-a-new-ai-company/) —
->   He's putting capital behind the position.
-> - [ECRI: AI chatbot misuse #1 health-tech hazard for 2026](https://www.medtechdive.com/news/ecri-health-tech-hazards-2026/810195/) —
->   Institutional, vertical-specific, structurally aligned.
->
-> **Counter / nuance:**
->
-> - [Chesky on chatbot partnerships, *Skift* August 2025](https://skift.com/2025/08/06/airbnbs-brian-chesky-were-open-to-partnering-with-ai-chatbots/) —
->   Eight months earlier, Chesky was open to chatbot *partnerships*.
->   He sharpened over time; he never ruled chatbots out as *one*
->   channel.
-> - [CaptainBook counter to Chesky, 2026](https://www.captainbook.io/blog/brian-chesky-wrong-about-ai-travel-booking) —
->   Argues the bottleneck is supply-side data infrastructure, not
->   the interface. When inventory is structured, the interface shape
->   is secondary.
->
-> *Evidence gap to acknowledge:* Beyond Chesky, no second CEO-level
-> named quote on the record as sharp. ECRI is the closest. This is
-> still an early-consensus position — the post should say so rather
-> than overclaim.
+> - **[Chesky on TBPN, May 8 2026 (via Benzinga)](https://www.benzinga.com/news/topics/26/05/52847666/airbnb-ceo-brian-chesky-chatbots-are-not-the-future-of-ai-consumer-products-are)** —
+>   *"I do not think a chatbot is the right interface for travel or
+>   e-commerce."* The exact quote and full context.
 
 ---
 

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -30,7 +30,7 @@ const { title, description, date, author, image, headings = [] } = Astro.props;
 
       <aside class="toc-aside">
         <div class="sticky top-20 max-h-[calc(100vh-5rem)] overflow-y-auto pr-4 -mr-4 pb-4">
-          <TableOfContents headings={headings} client:load />
+          <TableOfContents title={title} headings={headings} client:load />
         </div>
       </aside>
     </div>

--- a/src/lib/rehype-section-wrapper.mjs
+++ b/src/lib/rehype-section-wrapper.mjs
@@ -30,7 +30,7 @@ export default function rehypeSectionWrapper() {
 		const newSection = (children) => ({
 			type: 'element',
 			tagName: 'section',
-			properties: { className: ['prose-section', 'ink-bleed'] },
+			properties: { className: ['prose-section'] },
 			children,
 		});
 

--- a/src/lib/tweets.ts
+++ b/src/lib/tweets.ts
@@ -1,0 +1,165 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export interface TweetData {
+  id: string;
+  url: string;
+  text: string;
+  author: {
+    name: string;
+    handle: string;
+    avatar: string;
+    verified: boolean;
+  };
+  createdAt: string;
+  likes: number;
+  replies: number;
+}
+
+// Anchor to the project root (process.cwd()) so the cache survives
+// `dist/` rebuilds. import.meta.url would resolve relative to the
+// compiled module's location, which Vite emits inside dist/ during
+// the static build.
+const CACHE_DIR = path.join(process.cwd(), '.astro', 'tweet-cache');
+
+const memCache = new Map<string, TweetData>();
+
+export function parseTweetId(input: string): string {
+  if (/^\d+$/.test(input.trim())) return input.trim();
+  const m = input.match(/status(?:es)?\/(\d+)/);
+  if (m) return m[1];
+  throw new Error(
+    `Could not extract a tweet ID from "${input}". ` +
+      `Pass a full URL like https://x.com/<handle>/status/<id> or the ID itself.`,
+  );
+}
+
+// Token derivation used by X's own embed widget. The syndication
+// endpoint requires it; without it the request returns an HTML error
+// page rather than JSON. Identical to the algorithm in Vercel's
+// react-tweet — base-36 of (id / 1e15 * π) with zeros and the dot
+// removed.
+function deriveToken(id: string): string {
+  return ((Number(id) / 1e15) * Math.PI)
+    .toString(36)
+    .replace(/(0+|\.)/g, '');
+}
+
+async function readDiskCache(id: string): Promise<TweetData | null> {
+  try {
+    const raw = await fs.readFile(
+      path.join(CACHE_DIR, `${id}.json`),
+      'utf-8',
+    );
+    return JSON.parse(raw) as TweetData;
+  } catch {
+    return null;
+  }
+}
+
+async function writeDiskCache(id: string, data: TweetData): Promise<void> {
+  await fs.mkdir(CACHE_DIR, { recursive: true });
+  await fs.writeFile(
+    path.join(CACHE_DIR, `${id}.json`),
+    JSON.stringify(data, null, 2),
+    'utf-8',
+  );
+}
+
+interface SyndicationResponse {
+  text?: string;
+  created_at?: string;
+  favorite_count?: number;
+  conversation_count?: number;
+  display_text_range?: [number, number];
+  user?: {
+    name?: string;
+    screen_name?: string;
+    profile_image_url_https?: string;
+    verified?: boolean;
+  };
+}
+
+export async function fetchTweet(input: string): Promise<TweetData> {
+  const id = parseTweetId(input);
+
+  const cached = memCache.get(id);
+  if (cached) return cached;
+
+  const disk = await readDiskCache(id);
+  if (disk) {
+    memCache.set(id, disk);
+    return disk;
+  }
+
+  const token = deriveToken(id);
+  const endpoint =
+    `https://cdn.syndication.twimg.com/tweet-result?id=${id}&token=${token}`;
+
+  const res = await fetch(endpoint, {
+    headers: {
+      Accept: 'application/json',
+      'User-Agent': 'exitcondition.alrubinger.com (tweet-embed)',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `Tweet ${id} fetch failed (${res.status} ${res.statusText}). ` +
+        `The tweet may have been deleted, the account protected, or ` +
+        `the X syndication endpoint may be rate-limiting.`,
+    );
+  }
+
+  const contentType = res.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    throw new Error(
+      `Tweet ${id} fetch returned non-JSON (likely deleted or ` +
+        `protected). X serves an HTML error page in that case.`,
+    );
+  }
+
+  const json = (await res.json()) as SyndicationResponse;
+  if (!json?.text || !json?.user?.screen_name) {
+    throw new Error(
+      `Tweet ${id} response was missing required fields. ` +
+        `The syndication endpoint may have changed shape.`,
+    );
+  }
+
+  // display_text_range is the byte range X considers the user-facing
+  // tweet text — strips trailing media URLs and quoted-tweet links.
+  // When absent, fall back to the full text.
+  const range = json.display_text_range;
+  const visibleText =
+    range && range.length === 2
+      ? Array.from(json.text)
+          .slice(range[0], range[1])
+          .join('')
+      : json.text;
+
+  const data: TweetData = {
+    id,
+    url: `https://x.com/${json.user.screen_name}/status/${id}`,
+    text: visibleText.trim(),
+    author: {
+      name: json.user.name ?? json.user.screen_name,
+      handle: json.user.screen_name,
+      // _normal is the 48x48 thumbnail; _bigger (73x73) reads sharper
+      // at the 48px display size on retina displays.
+      avatar:
+        json.user.profile_image_url_https?.replace(
+          /_normal(\.[a-zA-Z]+)$/,
+          '_bigger$1',
+        ) ?? '',
+      verified: Boolean(json.user.verified),
+    },
+    createdAt: json.created_at ?? new Date(0).toISOString(),
+    likes: json.favorite_count ?? 0,
+    replies: json.conversation_count ?? 0,
+  };
+
+  await writeDiskCache(id, data);
+  memCache.set(id, data);
+  return data;
+}

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -7,9 +7,8 @@ import Signature from '@/components/Signature.astro';
 
 # Hi. I'm ALR.
 
-I think AI can be better for your team. Easy to share. Simple to improve. And friendlier than a blinking cursor in an empty chatbot.
-
-<SectionBreak />
+I think AI can be better for teams. Easy to share. Simple to improve. 
+Delightful to use. And friendlier than a blinking cursor in an empty chatbot.
 
 <div class="not-prose my-10 relative" aria-hidden="true">
   <input
@@ -22,7 +21,9 @@ I think AI can be better for your team. Easy to share. Simple to improve. And fr
   <span class="cursor-blink absolute left-5 top-1/2 -translate-y-1/2 w-[2px] h-7 bg-foreground"></span>
 </div>
 
-So I'm building [Aileron](https://docs.withaileron.ai/), a prototype that hides away the tech. Soon, it'll be a simple place to automate the routines you do every day. I want you to be **maximally creative and effective**.
+So I'm building [Aileron](https://docs.withaileron.ai/), a prototype that hides away the 
+tech. Soon, it'll be a simple place to automate the routines you do every day. 
+I want you to be **maximally creative and effective**.
 
 <SectionBreak />
 

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -8,18 +8,7 @@ import Signature from '@/components/Signature.astro';
 # Hi. I'm ALR.
 
 I think AI can be better for teams. Easy to share. Simple to improve. 
-Delightful to use. And friendlier than a blinking cursor in an empty chatbot.
-
-<div class="not-prose my-10 relative" aria-hidden="true">
-  <input
-    type="text"
-    value=""
-    readonly
-    tabindex="-1"
-    class="w-full rounded-md border border-border bg-card text-foreground text-lg lg:text-xl px-5 py-4 pointer-events-none focus:outline-none select-none caret-transparent"
-  />
-  <span class="cursor-blink absolute left-5 top-1/2 -translate-y-1/2 w-[2px] h-7 bg-foreground"></span>
-</div>
+Delightful to use. 
 
 So I'm building [Aileron](https://docs.withaileron.ai/), a prototype that hides away the 
 tech. Soon, it'll be a simple place to automate the routines you do every day. 

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -7,6 +7,8 @@ import Signature from '../../components/Signature.astro';
 import Tweet from '../../components/Tweet.astro';
 import Quote from '../../components/Quote.astro';
 import Callout from '../../components/Callout.astro';
+import Points from '../../components/Points.astro';
+import Point from '../../components/Point.astro';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts', ({ data }) =>
@@ -34,7 +36,7 @@ if (entry.data.author && !author) {
 // rehype-section-wrapper plugin. They render nothing themselves but
 // must be in scope for MDX so authors can use them without an
 // explicit import in every file.
-const components = { SectionBreak, SectionResume, Signature, Tweet, Quote, Callout };
+const components = { SectionBreak, SectionResume, Signature, Tweet, Quote, Callout, Points, Point };
 ---
 
 <PostLayout

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -4,6 +4,10 @@ import PostLayout from '../../layouts/PostLayout.astro';
 import SectionBreak from '../../lib/components/section-break.astro';
 import SectionResume from '../../lib/components/section-resume.astro';
 import Signature from '../../components/Signature.astro';
+import Tweet from '../../components/Tweet.astro';
+import Quote from '../../components/Quote.astro';
+import Callout from '../../components/Callout.astro';
+import BlinkingEyes from '../../components/BlinkingEyes.astro';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts', ({ data }) =>
@@ -31,7 +35,7 @@ if (entry.data.author && !author) {
 // rehype-section-wrapper plugin. They render nothing themselves but
 // must be in scope for MDX so authors can use them without an
 // explicit import in every file.
-const components = { SectionBreak, SectionResume, Signature };
+const components = { SectionBreak, SectionResume, Signature, Tweet, Quote, Callout, BlinkingEyes };
 ---
 
 <PostLayout

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -7,7 +7,6 @@ import Signature from '../../components/Signature.astro';
 import Tweet from '../../components/Tweet.astro';
 import Quote from '../../components/Quote.astro';
 import Callout from '../../components/Callout.astro';
-import BlinkingEyes from '../../components/BlinkingEyes.astro';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts', ({ data }) =>
@@ -35,7 +34,7 @@ if (entry.data.author && !author) {
 // rehype-section-wrapper plugin. They render nothing themselves but
 // must be in scope for MDX so authors can use them without an
 // explicit import in every file.
-const components = { SectionBreak, SectionResume, Signature, Tweet, Quote, Callout, BlinkingEyes };
+const components = { SectionBreak, SectionResume, Signature, Tweet, Quote, Callout };
 ---
 
 <PostLayout

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -130,7 +130,6 @@
 		margin-top: 0;
 		margin-bottom: 1.5rem;
 		color: var(--foreground);
-		filter: var(--effect-ink-bleed);
 	}
 	@media (min-width: 640px)  { :where(.prose) h1 { font-size: 3rem; } }
 	@media (min-width: 1024px) { :where(.prose) h1 { font-size: var(--role-display-size); } }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -83,6 +83,13 @@
 	* {
 		@apply border-border;
 	}
+	html {
+		/* Offset anchor-link jumps by the fixed header height (h-16 = 4rem)
+		 * plus a little breathing room, so headings land below the navbar
+		 * instead of being clipped behind it. */
+		scroll-padding-top: 5rem;
+		scroll-behavior: smooth;
+	}
 	body {
 		@apply bg-background text-foreground font-sans;
 		background-image: var(--pattern-page);


### PR DESCRIPTION
## Summary
- Revise *We Deserve More Than Chatbots*: trim the inline evidence blocks down to load-bearing sources and tighten the synthesis prose.
- Add `Point` / `Points` MDX components for numbered editorial callouts (monochrome, CSS-counter numbered, responsive row → stacked).
- `Quote` now supports year/month/day date precision.
- Table of contents gains a title entry at the top (h1 `#post-title`), and anchor jumps get header-aware `scroll-padding-top`.
- Add `@types/node` so `astro check` resolves the `node:fs` / `node:path` / `process` usage in `src/lib/tweets.ts` — this was failing CI on every build.

## Test plan
- [x] `pnpm check` passes (0 errors) — previously failed on tweets.ts node built-ins
- [x] `pnpm build` succeeds locally with the post in place
- [ ] Post renders correctly in dev and TOC/scroll behavior verified (author running locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)